### PR TITLE
Add env customization in pod template

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
           value: {{ .Values.debug.enabled | quote }}
         - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
           value: {{ .Values.debug.verbosity | quote }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
         ports:
         - name: http-metrics
           containerPort: 8383

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -10,6 +10,7 @@ image:
 # Deployment options for the operator pod.
 nodeSelector: {}
 podAnnotations: {}
+env: []
 tolerations: []
 resources: {}
 affinity: {}


### PR DESCRIPTION
My use case is the following: kiali operator is deployed behind a proxy that limits access to outside, so I need to be able to add the HTTPS_PROXY environment variable to check the latest version of Kiali on github.