### PR TITLE
do not install dashboards if they are disabled

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -56,28 +56,32 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Used to determine if a custom dashboard (defined in .Template.Name) should be deployed.
 */}}
 {{- define "kiali-server.isDashboardEnabled" -}}
-{{- $includere := "" }}
-{{- range $_, $s := .Values.deployment.custom_dashboards.includes }}
-  {{- if $s }}
-    {{- if $includere }}
-      {{- $includere = printf "%s|^%s$" $includere ($s | replace "*" ".*" | replace "?" ".") }}
-    {{- else }}
-      {{- $includere = printf "^%s$" ($s | replace "*" ".*" | replace "?" ".") }}
+{{- if .Values.external_services.custom_dashboards.enabled }}
+  {{- $includere := "" }}
+  {{- range $_, $s := .Values.deployment.custom_dashboards.includes }}
+    {{- if $s }}
+      {{- if $includere }}
+        {{- $includere = printf "%s|^%s$" $includere ($s | replace "*" ".*" | replace "?" ".") }}
+      {{- else }}
+        {{- $includere = printf "^%s$" ($s | replace "*" ".*" | replace "?" ".") }}
+      {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- $excludere := "" }}
-{{- range $_, $s := .Values.deployment.custom_dashboards.excludes }}
-  {{- if $s }}
-    {{- if $excludere }}
-      {{- $excludere = printf "%s|^%s$" $excludere ($s | replace "*" ".*" | replace "?" ".") }}
-    {{- else }}
-      {{- $excludere = printf "^%s$" ($s | replace "*" ".*" | replace "?" ".") }}
+  {{- $excludere := "" }}
+  {{- range $_, $s := .Values.deployment.custom_dashboards.excludes }}
+    {{- if $s }}
+      {{- if $excludere }}
+        {{- $excludere = printf "%s|^%s$" $excludere ($s | replace "*" ".*" | replace "?" ".") }}
+      {{- else }}
+        {{- $excludere = printf "^%s$" ($s | replace "*" ".*" | replace "?" ".") }}
+      {{- end }}
     {{- end }}
   {{- end }}
-{{- end }}
-{{- if (and (mustRegexMatch (default "no-matches" $includere) (base .Template.Name)) (not (mustRegexMatch (default "no-matches" $excludere) (base .Template.Name)))) }}
-  {{- print "enabled" }}
+  {{- if (and (mustRegexMatch (default "no-matches" $includere) (base .Template.Name)) (not (mustRegexMatch (default "no-matches" $excludere) (base .Template.Name)))) }}
+    {{- print "enabled" }}
+  {{- else }}
+    {{- print "" }}
+  {{- end }}
 {{- else }}
   {{- print "" }}
 {{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -54,6 +54,10 @@ deployment:
   version_label: ${HELM_IMAGE_TAG}
   view_only_mode: false
 
+external_services:
+  custom_dashboards:
+    enabled: true
+
 identity: {}
   #cert_file:
   #private_key_file:


### PR DESCRIPTION
If the user disabled dashboards, the helm chart will no longer install them. Note that helm will always install the CRD - the crds directory is not templated. So it is always installed.

see https://github.com/kiali/kiali/issues/3285

related operator PR: https://github.com/kiali/kiali-operator/pull/154