### PR TITLE
Be able to turn on profiler via helm setting.

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -64,7 +64,11 @@ spec:
         - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
           value: {{ .Values.debug.verbosity | quote }}
         - name: ANSIBLE_CONFIG
+        {{- if .Values.debug.enableProfiler }}
+          value: "/opt/ansible/ansible-profiler.cfg"
+        {{- else }}
           value: "/etc/ansible/ansible.cfg"
+        {{- end }}
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- end }}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -23,9 +23,11 @@ metrics:
 
 # debug.enabled: when true the full ansible logs are dumped after each reconciliation run
 # debug.verbosity: defines the amount of details the operator will log (higher numbers are more noisy)
+# debug.enableProfiler: when true (regardless of debug.enabled), timings for the most expensive tasks will be logged after each reconciliation loop
 debug:
   enabled: true
   verbosity: "1"
+  enableProfiler: false
 
 # Defines where the operator will look for Kial CR resources. "" means "all namespaces".
 watchNamespace: ""


### PR DESCRIPTION
This is going to be useful when running molecule tests and we want to see the profiling data. Just pass in `--set debug.enableProfiler=true` when installing via helm.

goes with https://github.com/kiali/kiali/issues/3469 and https://github.com/kiali/helm-charts/pull/20

part of fix for: https://github.com/kiali/kiali/issues/3489