### PR TITLE
[Proxy-config] Add port-forward permissions

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -200,8 +200,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -196,6 +196,12 @@ rules:
   {{- if eq .Values.onlyViewOnlyMode false }}
   - patch
   {{- end }}
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -21,6 +21,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -25,8 +25,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -22,6 +22,12 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -26,8 +26,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments


### PR DESCRIPTION
Kiali needs to port-forward against a pod in the mesh in order to get the envoy dump of an specific envoy.
This PR adds the necessary for the helm-charts to add the `post|create` permissions for the `pod/portforward` subresource.

Relates to kiali/kiali#3400
Relates to kiali/kiali-ui#2006
Needs https://github.com/kiali/kiali-operator/pull/213