### PR TITLE
Fix bad replacement when releasing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ node('kiali-build && fedora') {
     stage('Build and release Helm charts') {
       // Build the release
       echo "Will build version: ${releasingVersion}"
-      sh "sed -i -r 's/^VERSION \\?= v.*/VERSION \\?= ${releasingVersion}/' Makefile"
+      sh "sed -i -r 's/^VERSION \\?= v.*/VERSION \\?= v${releasingVersion}/' Makefile"
       sh "make clean update-helm-repos"
 
       // Tag the release


### PR DESCRIPTION
When releasing a `minor` version, a replacement is done to Makefiles to set the
version being released. This replacement is missing the "v" character
used in container image tags, leading to a reference to the wrong image
tags in the resulting helm charts.

This is adding the missing "v".

Fixes kiali/kiali#3617