### PR TITLE
Restore CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Helm charts
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make build-helm-charts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build
         run: make build-helm-charts
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-dist: xenial
-os: linux
-
-arch:
-- amd64
-
-script:
-# ensures the helm charts are valid
-- make build-helm-charts


### PR DESCRIPTION
Since TravisCI is no longer enabled, use GitHub actions for CI.