### PR TITLE
Fix the Ingress apiVersion so it isn't a deprecated version.

### DIFF
--- a/kiali-server/templates/ingress.yaml
+++ b/kiali-server/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 {{- if .Values.deployment.ingress_enabled }}
 ---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "kiali-server.fullname" . }}
@@ -31,9 +35,18 @@ spec:
   - http:
       paths:
       - path: {{ include "kiali-server.server.web_root" . }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "kiali-server.fullname" . }}
+            port:
+              number: {{ .Values.server.port }}
+        {{- else }}
         backend:
           serviceName: {{ include "kiali-server.fullname" . }}
           servicePort: {{ .Values.server.port }}
+        {{- end }}
     {{- if not (empty .Values.server.web_fqdn) }}
     host: {{ .Values.server.web_fqdn }}
     {{- end }}


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3706

To test, first build with `make build-helm-charts` and then run `helm template -n istio-system kiali-server _output/charts/kiali-server-1.36.0-SNAPSHOT.tgz` and look at the generated Ingress and see that it is using the appropriate api_version for your cluster (it will probably use the v1). You could also install it via `helm install -n istio-system kiali-server _output/charts/kiali-server-1.36.0-SNAPSHOT.tgz`