### PR TITLE
Helm v3 expects a default value for all keys

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         prometheus.io/port: {{ .Values.server.metrics_port | quote }}
         {{- else }}
         prometheus.io/scrape: "false"
-        prometheus.io/port: null
+        prometheus.io/port: ""
         {{- end }}
         kiali.io/runtimes: go,kiali
         {{- if .Values.deployment.pod_annotations }}


### PR DESCRIPTION
On Helm v3 I'm unable to use the chart with metrics_enabled="true" . 

`Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in Deployment.spec.template.metadata.annotations.prometheus.io/port`

