### PR TITLE
Annotate Kiali Service with external URL settings

### DIFF
--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -12,6 +12,13 @@ metadata:
     {{- end }}
     kiali.io/api-spec: https://kiali.io/api
     kiali.io/api-type: rest
+    {{- if and (not (empty .Values.server.web_fqdn)) (not (empty .Values.server.web_schema)) }}
+    {{- if empty .Values.server.web_port }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}{{ default "" .Values.server.web_root }}
+    {{- else }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}:{{ .Values.server.web_port }}{{(default "" .Values.server.web_root) }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.deployment.service_annotations }}
     {{- toYaml .Values.deployment.service_annotations | nindent 4  }}
     {{- end }}


### PR DESCRIPTION
Replicating changes of kiali/kiali-operator#264

Testing with these commands and visually checking the resulting YAML:

```bash
# Generates no annotation
helm template kiali-test ./kiali-server

# Generates no annotation
helm template --debug --set server.web_fqdn=example.com kiali-test ./kiali-server

# Generates no annotation
helm template --debug --set server.web_schema=https kiali-test ./kiali-server

# Generates kiali.io/external-url: https://example.com
helm template --debug --set server.web_fqdn=example.com --set server.web_schema=https kiali-test ./kiali-server

# Generates kiali.io/external-url: https://example.com/foo
helm template --debug --set server.web_fqdn=example.com --set server.web_schema=https kiali-test --set server.web_root=/foo ./kiali-server

# Generates kiali.io/external-url: https://example.com:55/foo
helm template --debug --set server.web_fqdn=example.com --set server.web_schema=https kiali-test --set server.web_root=/foo --set server.web_port=55 ./kiali-server
```

Related to kiali/kiali#3526