### PR TITLE
Removing PATCH verb from pods/proxy sub-resource

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -197,7 +197,6 @@ rules:
   - nodes
   - pods
   - pods/log
-  - pods/proxy
   - replicationcontrollers
   - services
   verbs:
@@ -213,6 +212,13 @@ rules:
   verbs:
   - create
   - post
+- apiGroups: [""]
+  resources:
+  - pods/proxy
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -14,7 +14,6 @@ rules:
   - nodes
   - pods
   - pods/log
-  - pods/proxy
   - replicationcontrollers
   - services
   verbs:
@@ -28,6 +27,13 @@ rules:
   verbs:
   - create
   - post
+- apiGroups: [""]
+  resources:
+  - pods/proxy
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets


### PR DESCRIPTION
fixes kiali/kiali#3878
part of kiali/kiali#3871
needs operator: https://github.com/kiali/kiali-operator/pull/290

![Screenshot of Kiali (23)](https://user-images.githubusercontent.com/613814/114859471-16c7cb80-9deb-11eb-8174-1f830a18710c.png)