### PR TITLE
be able to customize the length of the ansible profile report

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -62,6 +62,8 @@ spec:
           value: {{ .Values.allowAdHocKialiNamespace | quote }}
         - name: ALLOW_AD_HOC_KIALI_IMAGE
           value: {{ .Values.allowAdHocKialiImage | quote }}
+        - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+          value: "100"
         - name: ANSIBLE_DEBUG_LOGS
           value: {{ .Values.debug.enabled | quote }}
         - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO


### PR DESCRIPTION
I was using this as part of debugging https://github.com/kiali/kiali/issues/3892 - but this can be merged independent of that.

When you enable the profiler, show the top 100 tasks, not just the default 20