### PR TITLE
Add host stanza to Ingress

### DIFF
--- a/kiali-server/templates/ingress.yaml
+++ b/kiali-server/templates/ingress.yaml
@@ -34,6 +34,9 @@ spec:
         backend:
           serviceName: {{ include "kiali-server.fullname" . }}
           servicePort: {{ .Values.server.port }}
+    {{- if not (empty .Values.server.web_fqdn) }}
+    host: {{ .Values.server.web_fqdn }}
+    {{- end }}
   {{- end }}
 ...
 {{- end }}


### PR DESCRIPTION
Counterpart of https://github.com/kiali/kiali-operator/pull/298

Test 1: `helm template kiali-test ./kiali-server`
Generates:

```yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: kiali
  namespace: default
  labels:
    helm.sh/chart: kiali-server-0.0.0
    app: kiali
    app.kubernetes.io/name: kiali
    app.kubernetes.io/instance: kiali-test
    version: "${HELM_IMAGE_TAG}"
    app.kubernetes.io/version: "${HELM_IMAGE_TAG}"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: "kiali"
  annotations:
    # For ingress-nginx versions older than 0.20.0 use secure-backends.
    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
    # For ingress-nginx versions 0.20.0 and later use backend-protocol.
    nginx.ingress.kubernetes.io/secure-backends: "false"
    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
spec:
  rules:
  - http:
      paths:
      - path: /kiali
        backend:
          serviceName: kiali
          servicePort: 20001
...

```

Test 2: `helm template --set server.web_fqdn=example.com kiali-test ./kiali-server`
Generates:

```yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: kiali
  namespace: default
  labels:
    helm.sh/chart: kiali-server-0.0.0
    app: kiali
    app.kubernetes.io/name: kiali
    app.kubernetes.io/instance: kiali-test
    version: "${HELM_IMAGE_TAG}"
    app.kubernetes.io/version: "${HELM_IMAGE_TAG}"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: "kiali"
  annotations:
    # For ingress-nginx versions older than 0.20.0 use secure-backends.
    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
    # For ingress-nginx versions 0.20.0 and later use backend-protocol.
    nginx.ingress.kubernetes.io/secure-backends: "false"
    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
spec:
  rules:
  - http:
      paths:
      - path: /kiali
        backend:
          serviceName: kiali
          servicePort: 20001
    host: example.com
...
```