### PR TITLE
[helm] set app.kubernetes.io/instance label appropriately, define the new deployment.instance_name value

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -1,27 +1,17 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "kiali-server.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
+Create a default fully qualified instance name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+To simulate the way the operator works, use deployment.instance_name rather than the old fullnameOverride.
+For backwards compatibility, if fullnameOverride is not kiali but deployment.instance_name is kiali,
+use fullnameOverride, otherwise use deployment.instance_name.
 */}}
 {{- define "kiali-server.fullname" -}}
-{{- if .Values.fullnameOverride }}
-  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- if (and (eq .Values.deployment.instance_name "kiali") (ne .Values.fullnameOverride "kiali")) }}
+  {{- .Values.fullnameOverride | trunc 63 }}
 {{- else }}
-  {{- $name := default .Chart.Name .Values.nameOverride }}
-  {{- if contains $name .Release.Name }}
-    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-  {{- end }}
+  {{- .Values.deployment.instance_name | trunc 63 }}
 {{- end }}
 {{- end }}
 
@@ -48,7 +38,7 @@ Common labels
 */}}
 {{- define "kiali-server.labels" -}}
 helm.sh/chart: {{ include "kiali-server.chart" . }}
-app: {{ include "kiali-server.name" . }}
+app: kiali
 {{ include "kiali-server.selectorLabels" . }}
 version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
@@ -60,8 +50,8 @@ app.kubernetes.io/part-of: "kiali"
 Selector labels
 */}}
 {{- define "kiali-server.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "kiali-server.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: kiali
+app.kubernetes.io/instance: {{ include "kiali-server.fullname" . }}
 {{- end }}
 
 {{/*

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
     {{- $_ := set $cm "istio_namespace" (include "kiali-server.istio_namespace" .) }}
     {{- $_ := set $cm.auth "strategy" (include "kiali-server.auth.strategy" .) }}
     {{- $_ := set $cm.auth.openshift "client_id_prefix" (include "kiali-server.fullname" .) }}
+    {{- $_ := set $cm.deployment "instance_name" (include "kiali-server.fullname" .) }}
     {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}

--- a/kiali-server/templates/dashboards/envoy.yaml
+++ b/kiali-server/templates/dashboards/envoy.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: envoy

--- a/kiali-server/templates/dashboards/go.yaml
+++ b/kiali-server/templates/dashboards/go.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: go

--- a/kiali-server/templates/dashboards/kiali.yaml
+++ b/kiali-server/templates/dashboards/kiali.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: kiali

--- a/kiali-server/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
+++ b/kiali-server/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.0.6-jvm-pool

--- a/kiali-server/templates/dashboards/micrometer-1.0.6-jvm.yaml
+++ b/kiali-server/templates/dashboards/micrometer-1.0.6-jvm.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.0.6-jvm

--- a/kiali-server/templates/dashboards/micrometer-1.1-jvm.yaml
+++ b/kiali-server/templates/dashboards/micrometer-1.1-jvm.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.1-jvm

--- a/kiali-server/templates/dashboards/microprofile-1.1.yaml
+++ b/kiali-server/templates/dashboards/microprofile-1.1.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: microprofile-1.1

--- a/kiali-server/templates/dashboards/microprofile-x.y.yaml
+++ b/kiali-server/templates/dashboards/microprofile-x.y.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: microprofile-x.y

--- a/kiali-server/templates/dashboards/nodejs.yaml
+++ b/kiali-server/templates/dashboards/nodejs.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: nodejs

--- a/kiali-server/templates/dashboards/quarkus.yaml
+++ b/kiali-server/templates/dashboards/quarkus.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: quarkus

--- a/kiali-server/templates/dashboards/springboot-jvm-pool.yaml
+++ b/kiali-server/templates/dashboards/springboot-jvm-pool.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-jvm-pool

--- a/kiali-server/templates/dashboards/springboot-jvm.yaml
+++ b/kiali-server/templates/dashboards/springboot-jvm.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-jvm

--- a/kiali-server/templates/dashboards/springboot-tomcat.yaml
+++ b/kiali-server/templates/dashboards/springboot-tomcat.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-tomcat

--- a/kiali-server/templates/dashboards/thorntail.yaml
+++ b/kiali-server/templates/dashboards/thorntail.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: thorntail

--- a/kiali-server/templates/dashboards/tomcat.yaml
+++ b/kiali-server/templates/dashboards/tomcat.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: tomcat

--- a/kiali-server/templates/dashboards/vertx-client.yaml
+++ b/kiali-server/templates/dashboards/vertx-client.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-client

--- a/kiali-server/templates/dashboards/vertx-eventbus.yaml
+++ b/kiali-server/templates/dashboards/vertx-eventbus.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-eventbus

--- a/kiali-server/templates/dashboards/vertx-jvm.yaml
+++ b/kiali-server/templates/dashboards/vertx-jvm.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-jvm

--- a/kiali-server/templates/dashboards/vertx-pool.yaml
+++ b/kiali-server/templates/dashboards/vertx-pool.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-pool

--- a/kiali-server/templates/dashboards/vertx-server.yaml
+++ b/kiali-server/templates/dashboards/vertx-server.yaml
@@ -1,6 +1,6 @@
 {{- if (include "kiali-server.isDashboardEnabled" .) }}
 ---
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-server

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -1,4 +1,8 @@
-nameOverride: "kiali"
+# 'fullnameOverride' is deprecated. Use 'deployment.instance_name' instead.
+# This is only supported for backward compatibility and will be removed in a future version.
+# If 'fullnameOverride' is not "kiali" and 'deployment.instance_name' is "kiali",
+# then 'deployment.instance_name' will take the value of 'fullnameOverride' value.
+# Otherwise, 'fullnameOverride' is ignored and 'deployment.instance_name' is used.
 fullnameOverride: "kiali"
 
 # This is required for "openshift" auth strategy.
@@ -42,6 +46,7 @@ deployment:
   image_pull_secrets: []
   image_version: ${HELM_IMAGE_TAG}
   ingress_enabled: true
+  instance_name: "kiali"
   logger:
     log_format: "text"
     log_level: "info"


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4018

This only touches the kiali-server helm chart.

If you leave all defaults as-is, this works as before and you will not notice any differences. The only difference is if you want to set `fullnameOverride`.

To simulate the way the operator works, the kiali-server helm chart now uses `deployment.instance_name` rather than the now-deprecated `fullnameOverride`. For backwards compatibility, if `fullnameOverride` is not `kiali` but `deployment.instance_name` remains its default value of `kiali`, then `fullnameOverride` is used, otherwise `deployment.instance_name` is used. The old `nameOverride` is deprecated and now ignored.

A second commit in this PR merely removes the quotes from the dashboard apiVersion fields for consistency to all other resources.