### PR TITLE
Kiali monitoring dashboard updated to support new metrics

### DIFF
--- a/kiali-server/templates/dashboards/kiali.yaml
+++ b/kiali-server/templates/dashboards/kiali.yaml
@@ -11,6 +11,15 @@ spec:
   title: Kiali Internal Metrics
   items:
   - chart:
+      name: "API hit rate"
+      unit: "ops"
+      spans: 6
+      metricName: "kiali_api_processing_duration_seconds_count"
+      dataType: "rate"
+      aggregations:
+      - label: "route"
+        displayName: "API route"
+  - chart:
       name: "API processing duration"
       unit: "seconds"
       spans: 6
@@ -18,27 +27,25 @@ spec:
       dataType: "histogram"
       aggregations:
       - label: "route"
-        displayName: "Route"
+        displayName: "API route"
   - chart:
-      name: "Functions processing duration"
-      unit: "seconds"
-      spans: 6
-      metricName: "kiali_go_function_processing_duration_seconds"
-      dataType: "histogram"
-      aggregations:
-      - label: "function"
-        displayName: "Function"
-      - label: "package"
-        displayName: "Package"
-  - chart:
-      name: "Failures"
+      name: "API Failures"
       spans: 12
-      metricName: "kiali_go_function_failures_total"
+      metricName: "kiali_api_failures_total"
       dataType: "raw"
       aggregations:
-      - label: "function"
-        displayName: "Function"
-      - label: "package"
-        displayName: "Package"
+      - label: "route"
+        displayName: "API route"
+  - chart:
+      name: "Graph generation duration"
+      unit: "seconds"
+      spans: 12
+      metricName: "kiali_graph_generation_duration_seconds"  
+      dataType: "histogram"
+      aggregations:
+      - label: "graph_kind"
+        displayName: "Graph kind"
+      - label: "graph_type"
+        displayName: "Graph type"
 ...
 {{- end }}


### PR DESCRIPTION
Part of: [#3244](https://github.com/kiali/kiali/issues/3244)

This PR updates the Kiali monitoring dashboard to support:

- API failures metric
- Graph generation duration metric

Also removes the functions related metrics with the motivation of simplify the metrics exposed to users.