### PR TITLE
Always mount the kiali-cabundle volume/configmap

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -109,10 +109,8 @@ spec:
           mountPath: "/kiali-cert"
         - name: {{ include "kiali-server.fullname" . }}-secret
           mountPath: "/kiali-secret"
-        {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
         - name: {{ include "kiali-server.fullname" . }}-cabundle
           mountPath: "/kiali-cabundle"
-        {{- end }}
         {{- if .Values.deployment.resources }}
         resources:
         {{- toYaml .Values.deployment.resources | nindent 10 }}
@@ -135,10 +133,11 @@ spec:
         secret:
           secretName: {{ .Values.deployment.secret_name }}
           optional: true
-      {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
       - name: {{ include "kiali-server.fullname" . }}-cabundle
         configMap:
           name: {{ include "kiali-server.fullname" . }}-cabundle
+      {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+          optional: true
       {{- end }}
       {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
       affinity:


### PR DESCRIPTION
For Kubernetes, it is marked as optional. For OpenShift, it is still
mandatory.

Related operator PR: https://github.com/kiali/kiali-operator/pull/333

Related kiali/kiali#4050