### PR TITLE
No need for pods/proxy subresource so far

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -194,7 +194,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  - pods/proxy
   verbs:
   - get
   - list

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -11,7 +11,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  - pods/proxy
   verbs:
   - get
   - list

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -11,7 +11,6 @@ rules:
   - configmaps
   - endpoints
   - pods/log
-  - pods/proxy
   verbs:
   - get
   - list


### PR DESCRIPTION
needs https://github.com/kiali/kiali/pull/4108

There is no need to communicate with Istiod pods using the pod/proxy. Kubernetes assigns a PodIP accessible from all nodes of a cluster.