### PR TITLE
converting string to lower case

### DIFF
--- a/kiali-operator/templates/_helpers.tpl
+++ b/kiali-operator/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "kiali-operator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | lower | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -13,13 +13,13 @@ If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kiali-operator.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 63 | lower | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | lower | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kiali-operator.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | lower | trimSuffix "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
ServiceAccount and other resources fail 
```
[root@server kspyder-deploy]# helm template -f manifests/gkp-values.yaml --namespace test charts > operator.yaml
[root@server kspyder-deploy]# k apply -f operator.yaml
namespace/spyder unchanged
clusterrole.rbac.authorization.k8s.io/RELEASE-NAME-kiali-operator created
role.rbac.authorization.k8s.io/spyder-cni-psp-role unchanged
rolebinding.rbac.authorization.k8s.io/spyder-cni-psp-rolebinding unchanged
Error from server (Invalid): error when creating "operator.yaml": ServiceAccount "RELEASE-NAME-kiali-operator" is invalid: metadata.name: Invalid value: "RELEASE-NAME-kiali-operator": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "operator.yaml": ClusterRoleBinding.rbac.authorization.k8s.io "RELEASE-NAME-kiali-operator" is invalid: subjects[0].name: Invalid value: "RELEASE-NAME-kiali-operator": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
Error from server (Invalid): error when creating "operator.yaml": Deployment.apps "RELEASE-NAME-kiali-operator" is invalid: [metadata.name: Invalid value: "RELEASE-NAME-kiali-operator": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.template.spec.serviceAccountName: Invalid value: "RELEASE-NAME-kiali-operator": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]

```
This PR converts the upper case of RELEASE-NAME to lower case which is allowed by the k8s