### PR TITLE
Check Ingress is managed by networking.k8s.io/v1

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -97,6 +97,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - selfsubjectaccessreviews
+  verbs:
+  - list
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources:
   {{- if or (and (.Values.cr.create) (has "**" .Values.cr.spec.deployment.accessible_namespaces)) (.Values.clusterRoleCreator) }}

--- a/kiali-server/templates/ingress.yaml
+++ b/kiali-server/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 {{- if .Values.deployment.ingress_enabled }}
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/ingresses" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -35,7 +35,7 @@ spec:
   - http:
       paths:
       - path: {{ include "kiali-server.server.web_root" . }}
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
Kubernetes version 1.18 `networking.k8s.io/v1` only manages `networkpolicies`. 

`Ingress` are still `networking.k8s.io/v1beta1` until 1.19+

This change ensures  Ingress exists in v1, else use v1beta1 logic.

```
kubectl version --short
Client Version: v1.21.3
Server Version: v1.18.20-eks-8c579e
```
```
 kubectl get --raw /apis/networking.k8s.io/v1 | jq .
{
  "kind": "APIResourceList",
  "apiVersion": "v1",
  "groupVersion": "networking.k8s.io/v1",
  "resources": [
    {
      "name": "networkpolicies",
      "singularName": "",
      "namespaced": true,
      "kind": "NetworkPolicy",
      "verbs": [
        "create",
        "delete",
        "deletecollection",
        "get",
        "list",
        "patch",
        "update",
        "watch"
      ],
      "shortNames": [
        "netpol"
      ],
      "storageVersionHash": "YpfwF18m1G8="
    }
  ]
}
```
Related to [kubernetes issue 90077](https://github.com/kubernetes/kubernetes/issues/90077)

