### PR TITLE
Add feature flag for clustering/federation

### DIFF
--- a/kiali-server/templates/role-controlplane.yaml
+++ b/kiali-server/templates/role-controlplane.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kiali_feature_flags.clustering }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -13,3 +14,4 @@ rules:
   verbs:
   - list
 ...
+{{- end }}

--- a/kiali-server/templates/role-controlplane.yaml
+++ b/kiali-server/templates/role-controlplane.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kiali_feature_flags.clustering }}
+{{- if .Values.kiali_feature_flags.clustering.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/kiali-server/templates/role-controlplane.yaml
+++ b/kiali-server/templates/role-controlplane.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.kiali_feature_flags.clustering.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -8,10 +7,11 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
+{{- if .Values.kiali_feature_flags.clustering.enabled }}
 - apiGroups: [""]
   resources:
   - secrets
   verbs:
   - list
-...
 {{- end }}
+...

--- a/kiali-server/templates/rolebinding-controlplane.yaml
+++ b/kiali-server/templates/rolebinding-controlplane.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.kiali_feature_flags.clustering }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -15,3 +16,4 @@ subjects:
   name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ...
+{{- end }}

--- a/kiali-server/templates/rolebinding-controlplane.yaml
+++ b/kiali-server/templates/rolebinding-controlplane.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.kiali_feature_flags.clustering.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -16,4 +15,3 @@ subjects:
   name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ...
-{{- end }}

--- a/kiali-server/templates/rolebinding-controlplane.yaml
+++ b/kiali-server/templates/rolebinding-controlplane.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kiali_feature_flags.clustering }}
+{{- if .Values.kiali_feature_flags.clustering.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -72,6 +72,9 @@ identity: {}
   #cert_file:
   #private_key_file:
 
+kiali_feature_flags:
+  clustering: true
+
 login_token:
   signing_key: ""
 

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -73,8 +73,8 @@ identity: {}
   #private_key_file:
 
 kiali_feature_flags:
-  clustering: true
-
+  clustering:
+    enabled: true
 login_token:
   signing_key: ""
 


### PR DESCRIPTION
For now, this flag is only allowing or preventing creation of a role and
a rolebinding that grants privileges for reading some secrets in the
Istio namespace. There is no effect on Kiali server side, because it is
failing gracefully. In case it's needed later, this flag is being passed
to Kiali in its ConfigMap.

Default value is `true` for backwards compatibility.

Related kiali/kiali#4147