### PR TITLE
Ability to use a custom configmap

### DIFF
--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployment.configuration_configmap }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -23,3 +24,4 @@ data:
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...
+{{- end}}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
         - name: LOG_FORMAT
           value: "{{ .Values.deployment.logger.log_format }}"
         - name: LOG_TIME_FIELD_FORMAT
-          value: "{{ .Values.deployment.logger.time_field_format }}" 
+          value: "{{ .Values.deployment.logger.time_field_format }}"
         - name: LOG_SAMPLER_RATE
           value: "{{ .Values.deployment.logger.sampler_rate }}"
         volumeMounts:
@@ -118,7 +118,11 @@ spec:
       volumes:
       - name: {{ include "kiali-server.fullname" . }}-configuration
         configMap:
+          {{- if .Values.deployment.configuration_configmap }}
+          name: {{ .Values.deployment.configuration_configmap }}
+          {{- else }}
           name: {{ include "kiali-server.fullname" . }}
+          {{- end}}
       - name: {{ include "kiali-server.fullname" . }}-cert
         secret:
           {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -26,6 +26,9 @@ auth:
   strategy: ""
 
 deployment:
+  # This is a user defined configmap that should hold the configuration for Kiali. It will be used instead of the default one if set.
+  # The custom configmap should have a data entry for "config.yaml", which will be used by Kiali at startup.
+  configuration_configmap: ""
   # This only limits what Kiali will attempt to see, but Kiali Service Account has permissions to see everything.
   # For more control over what the Kial Service Account can see, use the Kiali Operator
   accessible_namespaces:


### PR DESCRIPTION
Hi folks,

This PR adds the option to use a custom configmap to configure kiali. This ability is useful in certain cases and users won't notice anything when using the default behaviour.