### PR TITLE
docs(values): add note regarding HELM_IMAGE_TAG and HELM_IMAGE_REPO

### DIFF
--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -1,9 +1,9 @@
 nameOverride: ""
 fullnameOverride: ""
 
-image:
-  repo: ${HELM_IMAGE_REPO}
-  tag: ${HELM_IMAGE_TAG}
+image: # see: https://quay.io/repository/kiali/kiali-operator?tab=tags
+  repo: ${HELM_IMAGE_REPO} # quay.io/kiali/kiali-operator
+  tag: ${HELM_IMAGE_TAG} # v1.39 # v1.39.0
   pullPolicy: Always
   pullSecrets: []
 

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -41,7 +41,7 @@ deployment:
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"
   image_pull_secrets: []
-  image_version: ${HELM_IMAGE_TAG}
+  image_version: ${HELM_IMAGE_TAG} # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
   ingress_enabled: true
   instance_name: "kiali"
   logger:
@@ -61,7 +61,7 @@ deployment:
   service_annotations: {}
   service_type: ""
   tolerations: []
-  version_label: ${HELM_IMAGE_TAG}
+  version_label: ${HELM_IMAGE_TAG} # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
   view_only_mode: false
 
 external_services:


### PR DESCRIPTION
It would have helped me to have the format of the repo and the image tag as a comment in the values file, as I use argo-cd for deployment.

If you consider this PR helpful, it can be merged.