### PR TITLE
fix kiali roles

### DIFF
--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -11,6 +11,7 @@ rules:
   - configmaps
   - endpoints
   - pods/log
+  - pods/proxy
   verbs:
   - get
   - list


### PR DESCRIPTION
When install kiali server alone, instead of operator, it will occurs Warning log such as below:
```
2021-09-16T10:07:04Z WRN GetPodProxyStatus is failing for [namespace: csminstalltest] [pod: reviews-v1-56b6cb7f4c-rq9nf]: unable to proxy Istiod pods. Make sure your Kubernetes API server has access to the Istio control plane through 8080 port
```

Refer to https://github.com/kiali/kiali/issues/3494#issuecomment-771612162, I found the RBAC role is missing pods/proxy permission.


Signed-off-by: zackzhangkai <zhang_kai@cestc.cn>