### PR TITLE
Add annotation in case of changing ConfigMap

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -70,7 +70,11 @@ Determine the default web root.
 */}}
 {{- define "kiali-server.server.web_root" -}}
 {{- if .Values.server.web_root  }}
-  {{- .Values.server.web_root | trimSuffix "/" }}
+  {{- if (eq .Values.server.web_root "/") }}
+    {{- .Values.server.web_root }}
+  {{- else }}
+    {{- .Values.server.web_root | trimSuffix "/" }}
+  {{- end }}
 {{- else }}
   {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
     {{- "/" }}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- toYaml .Values.deployment.pod_labels | nindent 8 }}
         {{- end }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.server.metrics_enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.server.metrics_port | quote }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -12,9 +12,9 @@ metadata:
     {{- end }}
     {{- if and (not (empty .Values.server.web_fqdn)) (not (empty .Values.server.web_schema)) }}
     {{- if empty .Values.server.web_port }}
-    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}{{ default "" .Values.server.web_root }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}{{ include "kiali-server.server.web_root" . }}
     {{- else }}
-    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}:{{ .Values.server.web_port }}{{(default "" .Values.server.web_root) }}
+    kiali.io/external-url: {{ .Values.server.web_schema }}://{{ .Values.server.web_fqdn }}:{{ .Values.server.web_port }}{{ include "kiali-server.server.web_root" . }}
     {{- end }}
     {{- end }}
     {{- if .Values.deployment.service_annotations }}


### PR DESCRIPTION
If a ConfigMap changes that does not trigger re-deployment of Kiali Server. 
Since the ConfigMap is used for configuring Kiali Server the "rebooting" the Server is required. 
Adding the annotation of kind
`checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}`
helps to force performing rollout of deployment and re-create the pod with Kiali Server.