### PR TITLE
Add root namespace property into Kiali config map

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -145,3 +145,14 @@ Determine the auth strategy to use - default is "token" on Kubernetes and "opens
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Determine the root namespace - default is where Kiali is installed.
+*/}}
+{{- define "kiali-server.external_services.istio.root_namespace" -}}
+{{- if .Values.external_services.istio.root_namespace }}
+  {{- .Values.external_services.istio.root_namespace }}
+{{- else }}
+  {{- .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
     {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
+    {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -69,6 +69,8 @@ deployment:
 external_services:
   custom_dashboards:
     enabled: true
+  istio:
+    root_namespace: ""
 
 identity: {}
   #cert_file:


### PR DESCRIPTION
This PR adds a new property for Istio, the root namespace (https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/).

If it is not configured it defaults to the namespace where Kiali is installed (usually istio-system), same logic from istio_namespace property.



