### PR TITLE
Ignore workload validation by default

### DIFF
--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
+    {{- $_ := set $cm.kiali_feature_flags.validations.ignore "root_namespace" (include "kiali-server.kiali_feature_flags.validations.ignore" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
-    {{- $_ := set $cm.kiali_feature_flags.validations.ignore "root_namespace" (include "kiali-server.kiali_feature_flags.validations.ignore" .) }}
+    {{- $_ := set $cm.kiali_feature_flags.validations "ignore" (include "kiali-server.kiali_feature_flags.validations.ignore" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -21,7 +21,6 @@ data:
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
-    {{- $_ := set $cm.kiali_feature_flags.validations "ignore" (include "kiali-server.kiali_feature_flags.validations.ignore" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}
 ...

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -93,6 +93,9 @@ kiali_feature_flags:
    - istio-ca-secret
   clustering:
     enabled: true
+  validations:
+    ignore: ["KIA1201"]
+
 login_token:
   signing_key: ""
 

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -87,10 +87,10 @@ identity: {}
 
 kiali_feature_flags:
   certificates_information_indicators:
-   enabled: true
-   secrets:
-   - cacerts
-   - istio-ca-secret
+    enabled: true
+    secrets:
+    - cacerts
+    - istio-ca-secret
   clustering:
     enabled: true
   validations:


### PR DESCRIPTION
Ignoring by default KIA1201 that relates to workload not covered by any auth policy. 

This is for [#4409](https://github.com/kiali/kiali/pull/4409).

The motivation for this is that is pretty common for some workloads to not have an Authorization Policy associated with them. So to avoid filling the UI with errors, we decided to make this validation optional.

![missing_ap_list](https://user-images.githubusercontent.com/1286393/145991421-b21087b2-fc9c-4b77-9c7d-ca01e2925a5d.png)

