### PR TITLE
Add a new CR setting. 

### DIFF
--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -103,6 +103,7 @@ login_token:
 
 server:
   port: 20001
+  redirect_path: ""
   metrics_enabled: true
   metrics_port: 9090
   web_root: ""


### PR DESCRIPTION
Adding a new config which can be used as in-memory replace in env.js file and using `server.web_root` as default if the value of new config is not specified.

**Linked issue:**
https://github.com/kiali/kiali/issues/4459

**Linked PRs:**
kiali: https://github.com/kiali/kiali/pull/4914
kiali-operator: https://github.com/kiali/kiali-operator/pull/510