### PR TITLE
[helm] Update the HPA api version to be used by default in the server helm chart

### DIFF
--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -39,7 +39,7 @@ deployment:
   custom_secrets: []
   host_aliases: []
   hpa:
-    api_version: "autoscaling/v2beta2"
+    api_version: "autoscaling/v2"
     spec: {}
   image_digest: "" # use "sha256" if image_version is a sha256 hash (do NOT prefix this value with a "@")
   image_name: quay.io/kiali/kiali


### PR DESCRIPTION
autoscaling API version `v2beta2` is being removed in newer clusters. Default the server helm chart to `v2`.

If you are running an older cluster that does not have `v2`, simply set this value to the `v2beta2` version at the same time you are define the `spec` for the HPA.

Part of: https://github.com/kiali/kiali/issues/5022