### PR TITLE
Add a fetch depth of 0 to GH action checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.release_branch }}       
-
+        fetch-depth: 0
+        
     - name: Prepare scripts
       run: |
         cat <<-EOF > bump.py


### PR DESCRIPTION
This is needed for the git commands to work. Something changed with the checkout action apparently (a very similar thing occured with the kiali.io pipeline before).