### PR TITLE
Fix release_type variable on next version calculation when scheduled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Determine next version
       if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
-        RELEASE_TYPE: ${{ github.event.inputs.release_type }}
+        RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
         RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
       id: next_version
       run: |


### PR DESCRIPTION
Today after GH unstability I see that the first scheduled run would have been failed due to this problem when pipeline is triggered by a scheduled cron.

This is not happening when is run manually, this PR is fixing this situation.