### PR TITLE
Set release branch in case of no manual input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [initialize]
     env:
-      RELEASE_TYPE: ${{ github.event.inputs.release_type }}      
+      RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.release_branch }}       
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0
         
     - name: Prepare scripts
@@ -151,13 +151,13 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.release_type }}      
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
-      BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
+      BRANCH_VERSION: ${{ github.event.inputs.release_branch || github.ref_name }} 
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}      
     steps:    
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.release_branch }} 
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0
         
     - name: Configure git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [initialize]
     env:
-      RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
+      RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,8 @@ jobs:
       RELEASE_TYPE: ${{ github.event.inputs.release_type }}      
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
-      BRANCH_VERSION: ${{ github.event.inputs.release_branch || github.ref_name }} 
-      RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}      
+      BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
+      RELEASE_BRANCH: ${{ github.event.inputs.release_branch || github.ref_name }} 
     steps:    
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
Similar to the fix in the operator, although this wasn't an issue, because in the absence of the value, it uses the default branch (master), but it's better to have a value just in case if in the future GH Actions implements some change in this behavior.

