### PR TITLE
feat: allow custom annotations on kiali cr

### DIFF
--- a/kiali-operator/templates/kiali-cr.yaml
+++ b/kiali-operator/templates/kiali-cr.yaml
@@ -11,11 +11,11 @@ metadata:
   name: {{ .Values.cr.name }}
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
-annotations:
-  ansible.sdk.operatorframework.io/verbosity: {{ .Values.debug.verbosity | quote }}
-  {{- if .Values.cr.annotations }}
-  {{- toYaml .Values.cr.annotations | nindent 2 }}
-  {{- end }}
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: {{ .Values.debug.verbosity | quote }}
+    {{- if .Values.cr.annotations }}
+    {{- toYaml .Values.cr.annotations | nindent 4 }}
+    {{- end }}
 spec:
   {{- toYaml .Values.cr.spec | nindent 2 }}
 ...

--- a/kiali-operator/templates/kiali-cr.yaml
+++ b/kiali-operator/templates/kiali-cr.yaml
@@ -13,6 +13,9 @@ metadata:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 annotations:
   ansible.sdk.operatorframework.io/verbosity: {{ .Values.debug.verbosity | quote }}
+  {{- if .Values.cr.annotations }}
+  {{- toYaml .Values.cr.annotations | nindent 2 }}
+  {{- end }}
 spec:
   {{- toYaml .Values.cr.spec | nindent 2 }}
 ...

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -77,9 +77,10 @@ cr:
   # then this is the namespace where the CR will be created (the default will be the operator namespace).
   namespace: ""
 
+  # Annotations to place in the Kiali CR metadata.
+  annotations: {}
+
   spec:
     deployment:
       accessible_namespaces:
       - '**'
-
-  annotations: {}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -81,3 +81,5 @@ cr:
     deployment:
       accessible_namespaces:
       - '**'
+
+  annotations: {}


### PR DESCRIPTION
This would allow specifying custom annotations on the kiali cr when it is created by the chart. I specifically need this so that I can tell Argo CD to have it in a later sync wave so during a delete operation the cr is removed before the operator.

(updated by @jmazzitelli July 8, 2022)
fixes: https://github.com/kiali/kiali/issues/5297