### PR TITLE
Fix image digest formatting

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: operator
-        image: "{{ .Values.image.repo }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ end }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ end }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
         args:
         - "--zap-log-level=info"

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
       {{- end }}
       containers:
-      - image: "{{ .Values.deployment.image_name }}{{ if .Values.deployment.image_digest }}@{{ .Values.deployment.image_digest }}{{ end }}:{{ .Values.deployment.image_version }}"
+      - image: "{{ .Values.deployment.image_name }}:{{ .Values.deployment.image_version }}{{ if .Values.deployment.image_digest }}@{{ .Values.deployment.image_digest }}{{ end }}"
         imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}
         name: {{ include "kiali-server.fullname" . }}
         command:


### PR DESCRIPTION
Currently, if you specify a digest in values.yaml, the image name generated is in the format:

quay.io/kiali/kiali@sha:{blah...}:v1.59.0

This is invalid

This PR will correct it to 

quay.io/kiali/kiali:v1.59.0@sha:{blah...}

Which is valid
