### PR TITLE
[kiali helm  chart] make operator volumes configurable

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -56,8 +56,11 @@ spec:
             - ALL
         {{- end }}
         volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
+        - mountPath: /ansible-operator/runner
           name: runner
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         env:
         - name: WATCH_NAMESPACE
           value: {{ .Values.watchNamespace | default "\"\""  }}
@@ -103,7 +106,10 @@ spec:
         {{- end }}
       volumes:
       - name: runner
-        emptyDir: {}
+        {{- toYaml .Values.runnerVolume | nindent 8 }}
+      {{- with .Values.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}
 ...

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -22,6 +22,21 @@ replicaCount: 1
 priorityClassName: ""
 securityContext: {}
 
+# runner volume config
+runnerVolume:
+  emptyDir: {}
+
+# Extra Volume Mounts
+extraVolumeMounts: []
+  # - name: tmp
+  #   mountPath: /tmp
+
+# Extra Volumes
+extraVolumes: []
+  # - name: tmp
+  #   emptyDir:
+  #     sizeLimit: 100Mi
+
 # metrics.enabled: set to true if you want Prometheus to collect metrics from the operator
 metrics:
   enabled: true


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

* make operator volumes in kiali helm  chart configurable
  * runner volume is configurable so something else like emptyDir can be used
  * runner mount directory has been change to /ansible-operator/runner
  * extraVolumes & extraVolumeMounts has been added

Some background:
We want to run all our containers which use an emptyDir volume with a configured sizeLimit and  the scurityContext "readOnlyRootFilesystem: true" should be set.

This was not possible with the kiali operator before, as it trys to write to /tmp. Therfore the volumes are configurable now. Sizelimit can be used or even some real pvc as backing storage.