### PR TITLE
Fix parameters from metrics scraping by prometheus

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
       {{- end }}
       annotations:
         prometheus.io/scrape: {{ .Values.metrics.enabled | quote }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
         {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/5949 [added by @jmazzitelli]

By default `metrics.enabled` set to `true`, this adds annotation `prometheus.io/scrape: true`. However there no annotations that describe what port and endpoint needs to be used:
```
    prometheus.io/path: /metrics
    prometheus.io/port: "8080"
```

If `kiali-operator` deployed with istio sidecar - sidecar trying to scrap applications metrics from default port `80`.

This triggers errors like this:
```
	 2023-03-25T22:34:09.768729Z	error	failed scraping application metrics: error scraping http://localhost:80/metrics: Get "http://localhost:80/metrics": dial tcp [::1]:80: connect: connection refused
```

To fix it - need to add annotations for `Deployment`:
```
    prometheus.io/path: /metrics
    prometheus.io/port: "8080"
```

You can also check thread in `istio.slack.com` here https://istio.slack.com/archives/C37A4KAAD/p1679928230016999