### PR TITLE
Support for updation of kiali-server helm value view_only_mode

### DIFF
--- a/kiali-server/templates/rolebinding.yaml
+++ b/kiali-server/templates/rolebinding.yaml
@@ -2,7 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- if or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous") }}
+  name: {{ include "kiali-server.fullname" . }}-viewer
+  {{- else }}
   name: {{ include "kiali-server.fullname" . }}
+  {{- end }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Prior to this change, the post installation update of the kiali-server helm chart value deployment.view_only_mode fails as it tries to change the roleRef which is immutable. This change tries to create a new clusterrolebinding based on the view_only_mode configuration.

Fixes https://github.com/kiali/kiali/issues/6139