### PR TITLE
feat: allow adding annotations for Kiali operator

### DIFF
--- a/kiali-operator/templates/serviceaccount.yaml
+++ b/kiali-operator/templates/serviceaccount.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kiali-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- include "kiali-operator.annotations" | nindent 4 }}
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 {{- if .Values.image.pullSecrets }}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -92,6 +92,9 @@ allowAllAccessibleNamespaces: true
 # of the Istio control plane namespace (which is typically, but not necessarily, "istio-system").
 accessibleNamespacesLabel: ""
 
+# When using a remote Prometheus server, setting up a service account annotation may be required. Setting up required annotations can be done using this property.
+kiali-operator:
+  annotations: ""
 # For what a Kiali CR spec can look like, see:
 # https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
 cr:


### PR DESCRIPTION
In situations where you are using a managed prometheus product like AWS AMP, you need to give the Kiali service account permissions to poll from the remote resource. Adding annotations when required will allow polling remote Prometheus hosts.