### PR TITLE
fix icon link in the helm charts metadata

### DIFF
--- a/kiali-operator/Chart.yaml
+++ b/kiali-operator/Chart.yaml
@@ -16,4 +16,4 @@ sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
+icon: https://raw.githubusercontent.com/kiali/kiali.io/current/assets/icons/logo.svg

--- a/kiali-server/Chart.yaml
+++ b/kiali-server/Chart.yaml
@@ -15,4 +15,4 @@ sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
+icon: https://raw.githubusercontent.com/kiali/kiali.io/current/assets/icons/logo.svg


### PR DESCRIPTION
we've been releasing the helm charts with a broken icon. This is a minor issue, but would be nice if we publish future charts that point to an existing icon.