### PR TITLE
check that the plugin image (version the same as the server) is published on quay

### DIFF
--- a/hack/smoke-test-release-branch.sh
+++ b/hack/smoke-test-release-branch.sh
@@ -176,6 +176,7 @@ fi
 # Determine the version we are going to smoke test
 OPERATOR_VERSION="$(ls -1 docs/kiali-operator-*.tgz | sort | tail -n1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 SERVER_VERSION="$(ls -1 docs/kiali-server-*.tgz | sort | tail -n1 | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+OSSMC_VERSION="${SERVER_VERSION}"
 
 if [ "${OPERATOR_VERSION}" != "${SERVER_VERSION}" ]; then
   abort_now "The latest helm chart versions for operator [${OPERATOR_VERSION}] and server [${SERVER_VERSION}] do not match. Aborting the test."
@@ -237,6 +238,14 @@ fi
 
 if ! ${HELM_EXE} uninstall --namespace ${SERVER_NAMESPACE} kiali-server; then
   abort_now "The Server Helm Chart was unable to perform an uninstall successfully. The smoke test has FAILED!"
+fi
+
+# SMOKE TESTING THAT THE OSSMC IMAGE IS ON QUAY.IO
+
+EXPECTED_OSSMC_IMAGE="quay.io/kiali/ossmconsole:v${OSSMC_VERSION}"
+infomsg "Checking that the OSSMC image is published on quay.io at: ${EXPECTED_OSSMC_IMAGE}"
+if ! docker pull ${EXPECTED_OSSMC_IMAGE} &>/dev/null ; then
+  abort_now "The OSSMC image is not published on quay.io. This is missing: [${EXPECTED_OSSMC_IMAGE}]. The smoke test has FAILED!"
 fi
 
 # SMOKE TESTING IS COMPLETE


### PR DESCRIPTION
This is what the action output will look like when the smoke test passes:

https://github.com/jmazzitelli/helm-charts/actions/runs/6693245429/job/18183991274?pr=3#step:3:83

This is what the action output will look like when the smoke test fails:

https://github.com/jmazzitelli/helm-charts/actions/runs/6693193706/job/18183839296?pr=3#step:3:84