### PR TITLE
have the release workflow run the smoketest.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,15 @@ jobs:
 
           git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
 
-          gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH
+          if hack/smoke-test-release-branch.sh --release-branch $BUILD_TAG; then
+            prtitle="Prepare for next version"
+            prmsg="Please merge to update version numbers and prepare for release $NEXT_VERSION"
+          else
+            prtitle="[DO NOT MERGE YET] Prepare for next version"
+            prmsg="DO NOT MERGE YET! The smoke test failed. Please fix the problem before merging this PR which updates version numbers and prepares for release $NEXT_VERSION"
+          fi
+
+          gh pr create -t "$prtitle" -b "$prmsg" -H $BUILD_TAG -B $RELEASE_BRANCH
           
         # For a patch release, everything is ready to publish the generated charts.
         # Let's push to master
@@ -229,8 +237,16 @@ jobs:
         then 
           git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
 
-          gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B master
-         
+          if hack/smoke-test-release-branch.sh --release-branch $BUILD_TAG; then
+            prtitle="Prepare for next version"
+            prmsg="Please merge to update version numbers and prepare for release $NEXT_VERSION"
+          else
+            prtitle="[DO NOT MERGE YET] Prepare for next version"
+            prmsg="DO NOT MERGE YET! The smoke test failed. Please fix the problem before merging this PR which updates version numbers and prepares for release $NEXT_VERSION"
+          fi
+
+          gh pr create -t "$prtitle" -b "$prmsg" -H $BUILD_TAG -B master
+
           # We did a patch release. In this case we need to go back to the version branch and do changes 
           # to the Makefile in that branch to record what's the current path release. Then, commit and push.
           # Also, a vX.Y.Z branch is created


### PR DESCRIPTION
 If it fails, title the PR with a loud warning and indicate it should not be merged. Otherwise, create the PR as it normally does.

fixes https://github.com/kiali/kiali/issues/6704