### PR TITLE
Add support for read-only root filesystem and enable by default

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: true
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
         - name: ALLOW_AD_HOC_KIALI_IMAGE
           value: {{ .Values.allowAdHocKialiImage | quote }}
         - name: ANSIBLE_LOCAL_TEMP
-          value: {{ .Values.localAnsibleTmpPath | quote }}
+          value: "/tmp/ansible/tmp"
 {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
         - name: ALLOW_AD_HOC_OSSMCONSOLE_IMAGE
           value: {{ .Values.allowAdHocOSSMConsoleImage | quote }}

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -84,8 +84,6 @@ spec:
           value: {{ .Values.allowAdHocKialiNamespace | quote }}
         - name: ALLOW_AD_HOC_KIALI_IMAGE
           value: {{ .Values.allowAdHocKialiImage | quote }}
-        - name: ANSIBLE_LOCAL_TEMP
-          value: "/tmp/ansible/tmp"
 {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
         - name: ALLOW_AD_HOC_OSSMCONSOLE_IMAGE
           value: {{ .Values.allowAdHocOSSMConsoleImage | quote }}
@@ -112,6 +110,8 @@ spec:
         {{- else }}
           value: "/etc/ansible/ansible.cfg"
         {{- end }}
+        - name: ANSIBLE_LOCAL_TEMP
+          value: "/tmp/ansible/tmp"
         {{- if .Values.env }}
         {{- toYaml .Values.env | nindent 8 }}
         {{- end }}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -89,11 +89,6 @@ allowSecurityContextOverride: false
 # Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
 allowAllAccessibleNamespaces: true
 
-# localAnsibleTmpPath is the path of the local Ansible temp directory. This sets the ANSIBLE_LOCAL_TEMP variable which
-# in turn sets the DEFAULT_LOCAL_TMP configuration. An emptyDir is mounted to /tmp for the kiali-operator container.
-# Ansible needs write access on this directory so modifying it might have implications if read-only root filesystem is enabled.
-localAnsibleTmpPath: /tmp/ansible/tmp
-
 # accessibleNamespacesLabel restricts the namespaces that a user can add to the Kiali CR spec.deployment.accessible_namespaces.
 # This value is either an empty string (which disables this feature) or a label name with an optional label value
 # (e.g. "mylabel" or "mylabel=myvalue"). Only namespaces that have that label will be permitted in


### PR DESCRIPTION
resolves kiali/kiali#6888
1. Mount emptyDir to /tmp instead of /tmp/ansible-operator/runner 
2. Define ANSIBLE_LOCAL_TEMP env variable to set path for Ansible temporary directory to /tmp/ansible/tmp instead of root filesystem. 
3. Create localAnsibleTmpPath in Values so users can set their own path.
4. Set readOnlyRootFilesystem to true in operator deployment.yaml to enable this feature by default.