### PR TITLE
Added additional_display_details to be default set.

### DIFF
--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -18,6 +18,11 @@ kiali_route_url: ""
 # Note that only those values used by the Helm Chart will be here.
 #
 
+additional_display_details:
+- annotation: kiali.io/api-spec
+  icon_annotation: kiali.io/api-type
+  title: API Documentation
+
 istio_namespace: "" # default is where Kiali is installed
 
 auth:


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/6665
Original feature: https://github.com/kiali/kiali/issues/1567

Make sure that in helm installation the "additional_display_details" a set, similar to operator one: https://github.com/kiali/kiali-operator/blob/master/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml#L8
