### PR TITLE
Enhacing kiali to be compatible with csi drivers/providers

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -135,14 +135,16 @@ spec:
         - name: {{ .name }}
           mountPath: "/kiali-remote-cluster-secrets/{{ .secret_name }}"
         {{- end }}
-        {{- if .Values.deployment.resources }}
-        resources:
-        {{- toYaml .Values.deployment.resources | nindent 10 }}
-        {{- end }}
+        {{- if .Values.deployment.csiEnabled }}
         {{- range .Values.deployment.csiVolumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
           readOnly: true
+        {{- end }}
+        {{- end }}
+        {{- if .Values.deployment.resources }}
+        resources:
+        {{- toYaml .Values.deployment.resources | nindent 10 }}
         {{- end }}
       volumes:
       - name: {{ include "kiali-server.fullname" . }}-configuration
@@ -184,6 +186,7 @@ spec:
         secret:
           secretName: {{ .secret_name }}
       {{- end }}
+      {{- if .Values.deployment.csiEnabled }}
       {{- range .Values.deployment.extraVolumes }}
       - name: {{ .name }}
         csi:
@@ -191,6 +194,7 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: {{ .secretProviderName }}
+      {{- end }}
       {{- end }}
       {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
       affinity:

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -190,7 +190,7 @@ spec:
       {{- range .Values.deployment.csiVolumes }}
       - name: {{ .name }}
         csi:
-          driver: secrets-store.csi.k8s.io
+          driver: {{ .driver }}
           readOnly: true
           volumeAttributes:
             secretProviderClass: {{ .secretProviderName }}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -193,7 +193,9 @@ spec:
           driver: {{ .driver }}
           readOnly: true
           volumeAttributes:
-            secretProviderClass: {{ .secretProviderName }}
+            {{- range $key, $val := .volumeAttributes }}
+            {{ $key }}: {{ $val }}
+            {{- end }}
       {{- end }}
       {{- end }}
       {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -187,7 +187,7 @@ spec:
           secretName: {{ .secret_name }}
       {{- end }}
       {{- if .Values.deployment.csiEnabled }}
-      {{- range .Values.deployment.extraVolumes }}
+      {{- range .Values.deployment.csiVolumes }}
       - name: {{ .name }}
         csi:
           driver: secrets-store.csi.k8s.io

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -139,6 +139,11 @@ spec:
         resources:
         {{- toYaml .Values.deployment.resources | nindent 10 }}
         {{- end }}
+        {{- range .Values.deployment.csiVolumeMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          readOnly: true
+        {{- end }}
       volumes:
       - name: {{ include "kiali-server.fullname" . }}-configuration
         configMap:
@@ -178,6 +183,14 @@ spec:
       - name: {{ .name }}
         secret:
           secretName: {{ .secret_name }}
+      {{- end }}
+      {{- range .Values.deployment.extraVolumes }}
+      - name: {{ .name }}
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderName }}
       {{- end }}
       {{- if or (.Values.deployment.affinity.node) (or (.Values.deployment.affinity.pod) (.Values.deployment.affinity.pod_anti)) }}
       affinity:

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
           mountPath: "/kiali-remote-cluster-secrets/{{ .secret_name }}"
         {{- end }}
         {{- if .Values.deployment.csiEnabled }}
-        {{- range .Values.deployment.csiVolumeMounts }}
+        {{- range .Values.deployment.csiVolumeMount }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
           readOnly: true
@@ -187,7 +187,7 @@ spec:
           secretName: {{ .secret_name }}
       {{- end }}
       {{- if .Values.deployment.csiEnabled }}
-      {{- range .Values.deployment.csiVolumes }}
+      {{- range .Values.deployment.csiVolume }}
       - name: {{ .name }}
         csi:
           driver: {{ .driver }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -42,6 +42,7 @@ deployment:
     pod_anti: {}
   configmap_annotations: {}
   csiEnabled: false  # Set this to true to enable CSI volume mounts
+  driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
   csiVolumeMounts:
     - name: ""      #name of volume mount
       mountPath: ""     #/path/for/csi/volume

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -42,10 +42,10 @@ deployment:
     pod_anti: {}
   configmap_annotations: {}
   csiEnabled: false  # Set this to true to enable CSI volume mounts
-  driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
   csiVolumeMounts:
     - name: ""      #name of volume mount
       mountPath: ""     #/path/for/csi/volume
+      driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
   csiVolumes:
     - name: ""         #volume name
       secretProviderName: ""     #secretproviderclass name

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -42,10 +42,10 @@ deployment:
     pod_anti: {}
   configmap_annotations: {}
   csiEnabled: false  # Set this to true to enable CSI volume mounts
-  csiVolumeMounts:
+  csiVolumeMount:
     - name: ""      #name of volume mount
       mountPath: ""     #/path/for/csi/volume
-  csiVolumes:
+  csiVolume:
     - name: ""         #volume name
       secretProviderName: ""     #secretproviderclass name
       driver: ""                 #  specify the csi driver to be used ex - disk.csi.azure.com

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -41,8 +41,13 @@ deployment:
     pod: {}
     pod_anti: {}
   configmap_annotations: {}
-  csiVolumeMounts: []
-  csiVolumes: []
+  csiEnabled: false  # Set this to true to enable CSI volume mounts
+  csiVolumeMounts:
+    - name: ""      #name of volume mount
+      mountPath: ""     #/path/for/csi/volume
+  csiVolumes:
+    - name: ""         #volume name
+      secretProviderName: ""     #secretproviderclass name
   custom_secrets: []
   host_aliases: []
   hpa:

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -48,7 +48,8 @@ deployment:
   csiVolumes:
     - name: ""         #volume name
       secretProviderName: ""     #secretproviderclass name
-      driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
+      driver: ""                 #  specify the csi driver to be used ex - disk.csi.azure.com
+      volumeAttributes: {}       #add volume attributes specific to each driver
   custom_secrets: []
   host_aliases: []
   hpa:

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -45,10 +45,10 @@ deployment:
   csiVolumeMounts:
     - name: ""      #name of volume mount
       mountPath: ""     #/path/for/csi/volume
-      driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
   csiVolumes:
     - name: ""         #volume name
       secretProviderName: ""     #secretproviderclass name
+      driver: "" #       specify the csi driver to be used ex - disk.csi.azure.com
   custom_secrets: []
   host_aliases: []
   hpa:

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -41,6 +41,8 @@ deployment:
     pod: {}
     pod_anti: {}
   configmap_annotations: {}
+  csiVolumeMounts: []
+  csiVolumes: []
   custom_secrets: []
   host_aliases: []
   hpa:


### PR DESCRIPTION
Since the addition of OIDC to Kiali - the insertion of the oidc-secret into the Kubernetes namespace has been a challenge. In scenarios where secrets cannot be inserted directly through kubectl but only through independent secret providers the secret store CSI driver would solve this. 
Since not everyone would be using this - I have also made it optional(or enabled) through values.yaml
The modifications include : 
 -Addition in values.yaml to specify values of csiVolume and Volume mounts
- Addtion of volume and volume mounts in deployment.yaml and their logic
- Secretstorage agnostic (works with every seceret management tool)

https://secrets-store-csi-driver.sigs.k8s.io/introduction