### PR TITLE
Fix default server metrics settings

### DIFF
--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -112,6 +112,8 @@ login_token:
 
 server:
   port: 20001
-  metrics_enabled: true
-  metrics_port: 9090
+  observability:
+    metrics:
+      enabled: true
+      port: 9090
   web_root: ""


### PR DESCRIPTION
Metrics default fields should fall under [observability](https://kiali.io/docs/configuration/kialis.kiali.io/#.spec.server.observability.metrics).