### PR TITLE
Add git config back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+        
+        git config user.name 'kiali-bot' 
         
     - name: Build Helm charts
       run: make -e VERSION=$RELEASE_VERSION clean build-helm-charts


### PR DESCRIPTION
We need to add some git configuration back into the pipeline because is required to push or create tags. Current releases failed because of this: https://github.com/kiali/helm-charts/actions/runs/7868923370 

For reference, this is the PR that made the change: https://github.com/kiali/helm-charts/pull/243

For now, until we investigate a way of removing this configuration, we will need it for release.