### PR TITLE
feat(kiali-server): add custom nodeport for service

### DIFF
--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
     protocol: TCP
     port: {{ .Values.server.port }}
-    {{- if eq .Values.deployment.service_type "NodePort" }}
+    {{- if and (not (empty .Values.server.node_port)) (eq .Values.deployment.service_type "NodePort") }}
     nodePort: {{ .Values.server.node_port }}
     {{- end }}
   {{- if .Values.server.observability.metrics.enabled }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -42,9 +42,6 @@ spec:
     appProtocol: http
     protocol: TCP
     port: {{ .Values.server.observability.metrics.port }}
-    {{- if eq .Values.deployment.service_type "NodePort" }}
-    nodePort: {{ .Values.server.observability.metrics.nodePort }}
-    {{- end }}
   {{- end }}
   selector:
     {{- include "kiali-server.selectorLabels" . | nindent 4 }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -34,11 +34,17 @@ spec:
   {{- end }}
     protocol: TCP
     port: {{ .Values.server.port }}
+    {{- if eq .Values.deployment.service_type "nodePort" }}
+    nodePort: {{ .Values.server.nodePort }}
+    {{- end }}
   {{- if .Values.server.observability.metrics.enabled }}
   - name: http-metrics
     appProtocol: http
     protocol: TCP
     port: {{ .Values.server.observability.metrics.port }}
+    {{- if eq .Values.deployment.service_type "nodePort" }}
+    nodePort: {{ .Values.server.observability.metrics.nodePort }}
+    {{- end }}
   {{- end }}
   selector:
     {{- include "kiali-server.selectorLabels" . | nindent 4 }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -35,7 +35,7 @@ spec:
     protocol: TCP
     port: {{ .Values.server.port }}
     {{- if eq .Values.deployment.service_type "NodePort" }}
-    nodePort: {{ .Values.server.nodePort }}
+    nodePort: {{ .Values.server.node_port }}
     {{- end }}
   {{- if .Values.server.observability.metrics.enabled }}
   - name: http-metrics

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
     protocol: TCP
     port: {{ .Values.server.port }}
-    {{- if eq .Values.deployment.service_type "nodePort" }}
+    {{- if eq .Values.deployment.service_type "NodePort" }}
     nodePort: {{ .Values.server.nodePort }}
     {{- end }}
   {{- if .Values.server.observability.metrics.enabled }}
@@ -42,7 +42,7 @@ spec:
     appProtocol: http
     protocol: TCP
     port: {{ .Values.server.observability.metrics.port }}
-    {{- if eq .Values.deployment.service_type "nodePort" }}
+    {{- if eq .Values.deployment.service_type "NodePort" }}
     nodePort: {{ .Values.server.observability.metrics.nodePort }}
     {{- end }}
   {{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -118,5 +118,4 @@ server:
     metrics:
       enabled: true
       port: 9090
-      nodePort: 32476
   web_root: ""

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -113,7 +113,7 @@ login_token:
 
 server:
   port: 20001
-  nodePort: 32475
+  node_port: 32475
   observability:
     metrics:
       enabled: true

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -113,6 +113,7 @@ login_token:
 
 server:
   port: 20001
+  #node_port:
   observability:
     metrics:
       enabled: true

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -113,7 +113,6 @@ login_token:
 
 server:
   port: 20001
-  node_port: 32475
   observability:
     metrics:
       enabled: true

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -113,8 +113,10 @@ login_token:
 
 server:
   port: 20001
+  nodePort: 32475
   observability:
     metrics:
       enabled: true
       port: 9090
+      nodePort: 32476
   web_root: ""


### PR DESCRIPTION
Related Issue ➜ [Kiali Server Helm Chart Support Custom NodePort](https://github.com/kiali/kiali/issues/7093)

When Kiali Server is deployed to hundreds of Kubernetes clusters, it would be very good to have this feature to access all clusters with the same `nodePort`. This PR was prepared to use a custom port for `NodePort`. 

In Values, we can get the nodePort value as follows:

```
server:
  port: 20001
  nodePort: 32475
  observability:
    metrics:
      enabled: true
      port: 9090
      nodePort: 32476
  web_root: ""
```

We can use it in the Service as follows:

```
{{- if eq .Values.deployment.service_type nodePort }}
    nodePort: {{ .Values.server.nodePort }}
{{- end }}
```

#7093