### PR TITLE
remove verbose_mode that has been deprecated

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -23,14 +23,10 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
-Identifies the log_level with the old verbose_mode and the new log_level considered.
+Identifies the log_level.
 */}}
 {{- define "kiali-server.logLevel" -}}
-{{- if .Values.deployment.verbose_mode -}}
-{{- .Values.deployment.verbose_mode -}}
-{{- else -}}
 {{- .Values.deployment.logger.log_level -}}
-{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
It has been deprecated/superceded since v1.26 (4 years ago)

part of: https://github.com/kiali/kiali/issues/7208