### PR TITLE
be able to set DNS policy and config on the Kiali pod

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -52,6 +52,15 @@ spec:
       hostAliases:
       {{- toYaml .Values.deployment.host_aliases | nindent 6 }}
       {{- end }}
+      {{- if .Values.deployment.dns }}
+      {{- if .Values.deployment.dns.policy }}
+      dnsPolicy: "{{ .Values.deployment.dns.policy }}"
+      {{- end }}
+      {{- if .Values.deployment.dns.config }}
+      dnsConfig:
+      {{- toYaml .Values.deployment.dns.config | nindent 8 }}
+      {{- end }}
+      {{- end }}
       containers:
       - image: "{{ .Values.deployment.image_name }}{{ if .Values.deployment.image_digest }}@{{ .Values.deployment.image_digest }}{{ end }}:{{ .Values.deployment.image_version }}"
         imagePullPolicy: {{ .Values.deployment.image_pull_policy | default "Always" }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -48,6 +48,9 @@ deployment:
     pod_anti: {}
   configmap_annotations: {}
   custom_secrets: []
+  dns:
+    config: {}
+    policy: ""
   host_aliases: []
   hpa:
     api_version: "autoscaling/v2"


### PR DESCRIPTION
part of https://github.com/kiali/kiali/issues/7150

To test, just run the `helm template` command to see the different Deployment yaml that can be produced. First make sure you build the helm charts so the PR changes are picked up locally (i.e. `make build-helm-charts`).

1. Set both dns policy and dns config:
```bash
helm template --set deployment.dns.policy="ClusterFirst" --set deployment.dns.config.options[0].name="ndots" --set-string deployment.dns.config.options[0].value="1" --set deployment.dns.config.nameservers[0]="11.22.33.44" --show-only templates/deployment.yaml _output/charts/kiali-server-1.85.0-SNAPSHOT.tgz | yq '.spec.template.spec' | yq eval '. | (.dnsPolicy, .dnsConfig)'
```
results in:
```yaml
ClusterFirst
nameservers:
  - 11.22.33.44
options:
  - name: ndots
    value: "1"
```
(the first line is the value of the dnsPolicy - the lines after are the dnsConfig)

2. Set dns policy
```bash
helm template --set deployment.dns.policy="ClusterFirst" --show-only templates/deployment.yaml _output/charts/kiali-server-1.85.0-SNAPSHOT.tgz | yq '.spec.template.spec' | yq eval '. | (.dnsPolicy, .dnsConfig)'
```
results in
```yaml
ClusterFirst
null
```

3. Set dns config:
```bash
helm template --set deployment.dns.config.options[0].name="ndots" --set-string deployment.dns.config.options[0].value="1" --set deployment.dns.config.nameservers[0]="11.22.33.44" --show-only templates/deployment.yaml _output/charts/kiali-server-1.85.0-SNAPSHOT.tgz | yq '.spec.template.spec' | yq eval '. | (.dnsPolicy, .dnsConfig)'
```
results in
```yaml
null
nameservers:
  - 11.22.33.44
options:
  - name: ndots
    value: "1"
```

4. Set nothing:
```bash
helm template --show-only templates/deployment.yaml _output/charts/kiali-server-1.85.0-SNAPSHOT.tgz | yq '.spec.template.spec' | yq eval '. | (.dnsPolicy, .dnsConfig)'
````
results in
```yaml
null
null
```