### PR TITLE
[kiali-server] adding ability to configure extra environment variables

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -123,6 +123,9 @@ spec:
           value: "{{ .Values.deployment.logger.time_field_format }}"
         - name: LOG_SAMPLER_RATE
           value: "{{ .Values.deployment.logger.sampler_rate }}"
+        {{- with .Values.deployment.extraEnvs }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: {{ include "kiali-server.fullname" . }}-configuration
           mountPath: "/kiali-configuration"

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -72,6 +72,7 @@ deployment:
     log_level: "info"
     time_field_format: "2006-01-02T15:04:05Z07:00"
     sampler_rate: "1"
+  extraEnvs: []
   node_selector: {}
   pod_annotations: {}
   pod_labels: {}


### PR DESCRIPTION
We noticed CPU throttling in Kiali due to GOMAXPROCS not being configured correctly. In order to fix this, we had to set the GOMAXPROCS environment variable in Kiali, however the helm chart currently does not have the ability to set additional environment variables.

This MR is adding the `extraEnvs` field to the kiali-server helm chart so that extra environment variables can be set in Kiali in a flexible way. An example of configuring this is below:

```
extraEnvs:
  - name: GOMAXPROCS
    value: "2"
  - name: test
    value: "true"
```

It then templates into the deployment like this:

```
env:
- name: ACTIVE_NAMESPACE
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
- name: LOG_LEVEL
   value: "info"
- name: LOG_FORMAT
   value: "text"
- name: LOG_TIME_FIELD_FORMAT
   value: "2006-01-02T15:04:05Z07:00"
- name: LOG_SAMPLER_RATE
   value: "1"
- name: GOMAXPROCS
   value: "2"
- name: test
   value: "true"
```

By default, it is set to `extraEnvs: []` so that no extra environment variables are passed.