### PR TITLE
Upgrade github actions to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,24 @@
 name: Helm charts
+
 on:
   push:
     branches:
-      - master
+    - master
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
+    - opened
+    - reopened
+    - synchronize
     branches:
-      - master
+    - master
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: make build-helm-charts
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build
+      run: make build-helm-charts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       branch_version: ${{ steps.branch_version.outputs.branch_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0
@@ -156,7 +156,7 @@ jobs:
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch || github.ref_name }} 
     steps:    
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }} 
         fetch-depth: 0

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -1,19 +1,23 @@
 name: Smoke test latest release
+
 on:
   pull_request:
     types:
-      - opened
-      - reopened
-      - synchronize
+    - opened
+    - reopened
+    - synchronize
     branches:
-      - master
+    - master
     paths:
-      - 'docs/index.yaml'
+    - 'docs/index.yaml'
+
 jobs:
   smoketest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Run smoke test hack script
-        run: hack/smoke-test-release-branch.sh --release-branch ${{ github.head_ref }}
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run smoke test hack script
+      run: hack/smoke-test-release-branch.sh --release-branch ${{ github.head_ref }}
 


### PR DESCRIPTION
Currently, github actions use v3 of actions/checkout, which internally runs on Node 16 (https://github.com/actions/checkout/blob/v3/action.yml#L90).

This PR upgrades github actions to v4, which internally runs Node on 20 (https://github.com/actions/checkout/blob/v4/action.yml#L102)