### PR TITLE
[fix] put signing key in a secret

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -61,6 +61,10 @@ Determine the default login token signing key.
 {{- end }}
 {{- end }}
 
+{{- define "kiali-server.login_token.signing_key_ref" -}}
+secret:{{  include "kiali-server.fullname" . }}-signing-key:key
+{{- end }}
+
 {{/*
 Determine the default web root.
 */}}

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
     {{- $_ := set $cm.deployment "instance_name" (include "kiali-server.fullname" .) }}
     {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
-    {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}
+    {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key_ref" .) }}
     {{- $_ := set $cm.external_services.istio "root_namespace" (include "kiali-server.external_services.istio.root_namespace" .) }}
     {{- $_ := set $cm.server "web_root" (include "kiali-server.server.web_root" .) }}
     {{- toYaml $cm | nindent 4 }}

--- a/kiali-server/templates/secret.yaml
+++ b/kiali-server/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kiali-server.fullname" . }}-signing-key
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  key: {{ include "kiali-server.login_token.signing_key" | b64enc }}


### PR DESCRIPTION
## What does this PR do?
- The `kiali-server` helm chart currently saves the `signing_key` in cleartext in a `ConfigMap`. This is a security risk if used in production ([Kiali Docs](https://kiali.io/docs/configuration/authentication/session-configs/#:~:text=It%20is%20possible%20to%20specify%20the%20signing%20key%20directly%20in%20the%20Kiali%20CR%2C%20in%20the%20spec.login_token.signing_key%20attribute.%20However%2C%20this%20should%20be%20only%20for%20testing%20purposes.%20The%20signing%20key%20is%20sensitive%20and%20should%20be%20treated%20like%20a%20password%20that%20must%20be%20protected.)).
- This PR changes the `kiali-server` chart to instead save the `signing_key` in a `Secret`, as recommended by that documentation.