### PR TITLE
ignore replicas if HPA is set

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 spec:
+{{- if not .Values.deployment.hpa.spec }}
   replicas: {{ .Values.deployment.replicas }}
+{{- end }}
   selector:
     matchLabels:
       {{- include "kiali-server.selectorLabels" . | nindent 6 }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -76,6 +76,7 @@ deployment:
   pod_annotations: {}
   pod_labels: {}
   priority_class_name: ""
+  # if deployment.hpa is defined, this replicas setting will be ignored
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/7559

To test this:

1. Create this file (`/tmp/values.yaml`) - note that HPA is defined and an abnormally large value for `deployment.replicas` is set - you will notice that large replicas value won't appear in the generated yaml:
```yaml
deployment:
  replicas: 123456
  hpa:
    spec:
      maxReplicas: 6
      minReplicas: 3
      metrics:
      - type: Resource
        resource:
          name: cpu
          target:
            type: Utilization
            averageUtilization: 70
      - type: Resource
        resource:
          name: memory
          target:
            type: Utilization
            averageUtilization: 70
  resources:
    requests:
      memory: "1Gi"
    limits:
      memory: "2Gi"
```

2. Check out this PR branch and build the helm charts: `make build-helm-charts`
3. Show the deployment and HPA templates using that values file:
```
helm template -f /tmp/values.yaml --show-only templates/deployment.yaml --show-only templates/hpa.yaml  _output/charts/kiali-server-*.tgz
```
4. Notice that there is an HPA resource generated in the output.
5. Notice there is NO `spec.replicas` in the generated Deployment (notice the large value for replicas does not appear in the output):
```
helm template -f /tmp/values.yaml --show-only templates/deployment.yaml --show-only templates/hpa.yaml  _output/charts/kiali-server-*.tgz | grep 123456
```
6. Now see that setting `spec.replicas` still takes effect if HPA is not defined (HPA is not defined by default, so just set the replicas on the command line, no need for a values file specified on the command line for this test, and only dump the deployment template since there is no HPA template for this test):
```
$ helm template --set deployment.replicas=123456 --show-only templates/deployment.yaml  _output/charts/kiali-server-*.tgz | grep 123456
  replicas: 123456
```