### PR TITLE
Grant kiali role list permissions for mutating webhooks

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -312,4 +312,11 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
 ...

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -92,5 +92,12 @@ rules:
   - {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
   verbs:
   - get
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
 ...
 {{- end -}}

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -99,5 +99,12 @@ rules:
   - {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
   verbs:
   - get
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
 ...
 {{- end -}}


### PR DESCRIPTION
This is necessary to read tags in the cluster.

