### PR TITLE
support namespaces with just numerals in their names

### DIFF
--- a/kiali-operator/templates/clusterrolebinding.yaml
+++ b/kiali-operator/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole
   name: {{ include "kiali-operator.fullname" . }}

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 spec:
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       name: {{ include "kiali-operator.fullname" . }}
-      namespace: {{ .Release.Namespace }}
+      namespace: "{{ .Release.Namespace }}"
       labels:
         # required for the operator SDK metric service selector
         name: {{ include "kiali-operator.fullname" . }}

--- a/kiali-operator/templates/kiali-cr.yaml
+++ b/kiali-operator/templates/kiali-cr.yaml
@@ -4,9 +4,9 @@ apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
   {{- if .Values.watchNamespace }}
-  namespace: {{ .Values.watchNamespace }}
+  namespace: "{{ .Values.watchNamespace }}"
   {{- else if .Values.cr.namespace }}
-  namespace: {{ .Values.cr.namespace }}
+  namespace: "{{ .Values.cr.namespace }}"
   {{- end }}
   name: {{ .Values.cr.name }}
   labels:

--- a/kiali-operator/templates/serviceaccount.yaml
+++ b/kiali-operator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 {{- if .Values.image.pullSecrets }}

--- a/kiali-server/templates/cabundle.yaml
+++ b/kiali-server/templates/cabundle.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kiali-server.fullname" . }}-cabundle
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
   annotations:

--- a/kiali-server/templates/configmap.yaml
+++ b/kiali-server/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
   {{- if .Values.deployment.configmap_annotations }}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 spec:

--- a/kiali-server/templates/hpa.yaml
+++ b/kiali-server/templates/hpa.yaml
@@ -4,7 +4,7 @@ apiVersion: {{ .Values.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 spec:

--- a/kiali-server/templates/ingress.yaml
+++ b/kiali-server/templates/ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- if .Values.deployment.ingress.additional_labels }}
     {{- toYaml .Values.deployment.ingress.additional_labels | nindent 4 }}

--- a/kiali-server/templates/oauth.yaml
+++ b/kiali-server/templates/oauth.yaml
@@ -5,7 +5,7 @@ apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
   name: {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 redirectURIs:

--- a/kiali-server/templates/role-controlplane.yaml
+++ b/kiali-server/templates/role-controlplane.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kiali-server.fullname" . }}-controlplane
-  namespace: {{ include "kiali-server.istio_namespace" . }}
+  namespace: "{{ include "kiali-server.istio_namespace" . }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:

--- a/kiali-server/templates/rolebinding-controlplane.yaml
+++ b/kiali-server/templates/rolebinding-controlplane.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kiali-server.fullname" . }}-controlplane
-  namespace: {{ include "kiali-server.istio_namespace" . }}
+  namespace: "{{ include "kiali-server.istio_namespace" . }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 roleRef:
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 ...

--- a/kiali-server/templates/rolebinding.yaml
+++ b/kiali-server/templates/rolebinding.yaml
@@ -20,5 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 ...

--- a/kiali-server/templates/route.yaml
+++ b/kiali-server/templates/route.yaml
@@ -6,7 +6,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- if .Values.deployment.ingress.additional_labels }}
     {{- toYaml .Values.deployment.ingress.additional_labels | nindent 4 }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
   annotations:

--- a/kiali-server/templates/serviceaccount.yaml
+++ b/kiali-server/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kiali-server.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 ...


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/7773

To test:

### server helm chart

1. `make build-helm-charts`
2. `kubectl create ns 12345`
3. `helm install --namespace 12345 kiali-server _output/charts/kiali-server*.tgz`

It should install fine, with no errors from helm. The server won't start because its trying to pull an image that doesn't exist, but that is irrelevant for this issue. We just want to make sure helm does not fail.

You can uninstall with:
```
helm uninstall --namespace 12345 kiali-server
```

### operator helm chart

1. `make build-helm-charts`
2. `kubectl create ns 12345`
3. `helm install --namespace 12345 --set cr.create=true kiali-operator _output/charts/kiali-operator*.tgz`

It should install fine, with no errors from helm. The operator won't start because its trying to pull an image that doesn't exist, but that is irrelevant for this issue. We just want to make sure helm does not fail.

You can uninstall with deleting the CR first, then the operator:
```
kubectl delete kiali -n 12345 --all && helm uninstall -n 12345 kiali-operator
```
