### PR TITLE
add support for custom environment variables to the server deployment

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -125,6 +125,10 @@ spec:
           value: "{{ .Values.deployment.logger.time_field_format }}"
         - name: LOG_SAMPLER_RATE
           value: "{{ .Values.deployment.logger.sampler_rate }}"
+        {{- range .Values.deployment.custom_envs }}
+        - name: {{ .name | quote }}
+          value: {{ .value | quote }}
+        {{- end }}
         volumeMounts:
         - name: {{ include "kiali-server.fullname" . }}-configuration
           mountPath: "/kiali-configuration"

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -39,6 +39,8 @@ deployment:
   # For more control over what the Kial Service Account can see, use the Kiali Operator.
   cluster_wide_access: true
   configmap_annotations: {}
+  # custom environment variables
+  custom_envs: []
   custom_secrets: []
   dns:
     config: {}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -39,7 +39,6 @@ deployment:
   # For more control over what the Kial Service Account can see, use the Kiali Operator.
   cluster_wide_access: true
   configmap_annotations: {}
-  # custom environment variables
   custom_envs: []
   custom_secrets: []
   dns:


### PR DESCRIPTION
a corporate L7 proxy sits between my kiali deployment and my prometheus server. I need to specify the (HTTP|HTTPS|NO)_PROXY environment variables in my helm chart deployment.

part of: https://github.com/kiali/kiali/issues/7569