### PR TITLE
Managed-by should only be set by `helm` or similar at install time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ clean:
 	        i386)   arch="386" ;; \
 	        i686)   arch="386" ;; \
 	        x86_64) arch="amd64" ;; \
-	        arm|arm64)    dpkg --print-architecture | grep -q "arm64" && arch="arm64" || arch="arm" ;; \
+	        arm) arch="arm" ;; \
+	        arm64|aarch64) arch="arm64" ;; \
 	    esac ;\
 	    cd "${OUTDIR}/helm-install" ;\
 	    curl -L "https://get.helm.sh/helm-${HELM_VERSION}-$${os}-$${arch}.tar.gz" > "${OUTDIR}/helm-install/helm.tar.gz" ;\

--- a/kiali-operator/templates/_helpers.tpl
+++ b/kiali-operator/templates/_helpers.tpl
@@ -42,7 +42,6 @@ app: {{ include "kiali-operator.name" . }}
 version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: "kiali-operator"
 {{- end }}
 

--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -32,7 +32,6 @@ app: kiali
 {{ include "kiali-server.selectorLabels" . }}
 version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Values.deployment.version_label | default .Chart.AppVersion | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: "kiali"
 {{- end }}
 


### PR DESCRIPTION
1. `app.kubernetes.io/managed-by: Helm` is automatically applied to resources _installed_ by Helm, and does not need to be (read: should not be) manually templated. The label is an install-time label that should be applied by the tool actually installing the resources into the cluster.

This matters because `helm template` should (and by default will) produce YAML without this label, as it is unknown at template-time what will "manage" the resource.

2. Also fix the `makefile` so it doesn't try to download the wrong Helm bin on linux/arm64.

_(@jmazzitelli added the fixes line below)_
fixes: https://github.com/istio/istio/issues/53698