### PR TITLE
support remote_cluster_resources_only=true and support redirect_uris for openshift oauthclient

### DIFF
--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -20,11 +20,7 @@ Create chart name and version as used by the chart label.
 Determine if on OpenShift (when debugging the chart for OpenShift use-cases, set "simulateOpenShift")
 */}}
 {{- define "kiali-server.isOpenShift" -}}
-{{- if .Values.simulateOpenShift -}}
-true
-{{- else }}
-{{- .Capabilities.APIVersions.Has "operator.openshift.io/v1" -}}
-{{- end -}}
+{{- .Values.isOpenShift | default (.Capabilities.APIVersions.Has "operator.openshift.io/v1") -}}
 {{- end }}
 
 {{/*

--- a/kiali-server/templates/cabundle.yaml
+++ b/kiali-server/templates/cabundle.yaml
@@ -1,4 +1,5 @@
-{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if eq "true" (include "kiali-server.isOpenShift" .) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -10,4 +11,5 @@ metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 ...
+{{- end }}
 {{- end }}

--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -162,7 +163,7 @@ spec:
           name: {{ include "kiali-server.fullname" . }}
       - name: {{ include "kiali-server.fullname" . }}-cert
         secret:
-          {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+          {{- if eq "true" (include "kiali-server.isOpenShift" .) }}
           secretName: {{ include "kiali-server.fullname" . }}-cert-secret
           {{- else }}
           secretName: istio.{{ include "kiali-server.fullname" . }}-service-account
@@ -177,7 +178,7 @@ spec:
       - name: {{ include "kiali-server.fullname" . }}-cabundle
         configMap:
           name: {{ include "kiali-server.fullname" . }}-cabundle
-      {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+      {{- if not (eq "true" (include "kiali-server.isOpenShift" .)) }}
           optional: true
       {{- end }}
       {{- range .Values.deployment.custom_secrets }}
@@ -226,3 +227,4 @@ spec:
       {{- toYaml .Values.deployment.node_selector | nindent 8 }}
       {{- end }}
 ...
+{{- end }}

--- a/kiali-server/templates/hpa.yaml
+++ b/kiali-server/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
 {{- if .Values.deployment.hpa.spec }}
 ---
 apiVersion: {{ .Values.deployment.hpa.api_version }}
@@ -14,4 +15,5 @@ spec:
     name: {{ include "kiali-server.fullname" . }}
   {{- toYaml .Values.deployment.hpa.spec | nindent 2 }}
 ...
+{{- end }}
 {{- end }}

--- a/kiali-server/templates/ingress.yaml
+++ b/kiali-server/templates/ingress.yaml
@@ -1,4 +1,5 @@
-{{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if not (eq "true" (include "kiali-server.isOpenShift" .)) }}
 {{- if eq "true" (include "kiali-server.deployment.ingress.enabled" .) }}
 ---
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
@@ -58,5 +59,6 @@ spec:
     {{- end }}
   {{- end }}
 ...
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kiali-server/templates/oauth.yaml
+++ b/kiali-server/templates/oauth.yaml
@@ -1,5 +1,5 @@
-{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
-{{- if .Values.kiali_route_url }}
+{{- if eq "true" (include "kiali-server.isOpenShift" .) }}
+{{- if (or (.Values.kiali_route_url) (.Values.auth.openshift.redirect_uris)) }}
 ---
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
@@ -9,9 +9,15 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 redirectURIs:
+{{- if .Values.auth.openshift.redirect_uris }}
+{{- range .Values.auth.openshift.redirect_uris }}
+- {{ . }}
+{{- end }}
+{{- else }}
 - {{ .Values.kiali_route_url }}/api/auth/callback
 {{- if .Values.server.web_port }}
 - {{ .Values.kiali_route_url }}:{{ .Values.server.web_port }}/api/auth/callback
+{{- end }}
 {{- end }}
 grantMethod: auto
 {{- if .Values.auth.openshift.token_inactivity_timeout }}

--- a/kiali-server/templates/route.yaml
+++ b/kiali-server/templates/route.yaml
@@ -1,4 +1,5 @@
-{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if eq "true" (include "kiali-server.isOpenShift" .) }}
 {{- if eq "true" (include "kiali-server.deployment.ingress.enabled" .) }}
 # As of OpenShift 4.5, need to use --disable-openapi-validation when installing via Helm
 ---
@@ -30,5 +31,6 @@ spec:
     targetPort: {{ .Values.server.port }}
   {{- end }}
 ...
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kiali-server/templates/service.yaml
+++ b/kiali-server/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
 ---
 apiVersion: v1
 kind: Service
@@ -7,7 +8,7 @@ metadata:
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
   annotations:
-    {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+    {{- if eq "true" (include "kiali-server.isOpenShift" .) }}
     service.beta.openshift.io/serving-cert-secret-name: {{ include "kiali-server.fullname" . }}-cert-secret
     {{- end }}
     {{- if and (not (empty .Values.server.web_fqdn)) (not (empty .Values.server.web_schema)) }}
@@ -49,3 +50,4 @@ spec:
   {{- toYaml .Values.deployment.additional_service_yaml | nindent 2  }}
   {{- end }}
 ...
+{{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -69,6 +69,7 @@ deployment:
   pod_annotations: {}
   pod_labels: {}
   priority_class_name: ""
+  remote_cluster_resources_only: false
   # if deployment.hpa is defined, this replicas setting will be ignored
   replicas: 1
   resources:


### PR DESCRIPTION
this refactor the way we determine if it is an OpenShift cluster (for easier testing and maintenance)

part of https://github.com/kiali/kiali/issues/7861

To test quickly run this 4-part command:

```
echo -e "\nK8s full install:\n" && helm template -n istio-system --set deployment.ingress.enabled=true --set isOpenShift=false kiali-server _output/charts/kiali-server-*.tgz | grep "^kind:" && echo -e "\nOpenShift full install\n" && helm template -n istio-system --set deployment.ingress.enabled=true --set auth.openshift.redirect_uris[0]=foo --set isOpenShift=true kiali-server _output/charts/kiali-server-*.tgz | grep "^kind:" && echo -e "\nK8s remote only install:\n" && helm template -n istio-system --set deployment.ingress.enabled=true --set deployment.remote_cluster_resources_only=true --set isOpenShift=false kiali-server _output/charts/kiali-server-*.tgz | grep "^kind:" && echo -e "\nOpenShift remote only install\n" && helm template -n istio-system --set deployment.remote_cluster_resources_only=true --set deployment.ingress.enabled=true --set auth.openshift.redirect_uris[0]=foo --set isOpenShift=true kiali-server _output/charts/kiali-server-*.tgz | grep "^kind:"
```

and see that only some resources are created when remote_cluster_resources_only is true:

```

K8s full install:

kind: ServiceAccount
kind: ConfigMap
kind: ClusterRole
kind: ClusterRoleBinding
kind: Service
kind: Deployment
kind: Ingress

OpenShift full install

kind: ServiceAccount
kind: ConfigMap
kind: ConfigMap
kind: ClusterRole
kind: ClusterRoleBinding
kind: Service
kind: Deployment
kind: OAuthClient
kind: Route

K8s remote only install:

kind: ServiceAccount
kind: ConfigMap
kind: ClusterRole
kind: ClusterRoleBinding

OpenShift remote only install

kind: ServiceAccount
kind: ConfigMap
kind: ClusterRole
kind: ClusterRoleBinding
kind: OAuthClient
```

Notice things like the ingress/route, service, and deployment are not installed when we just want the remote cluster resources created.