### PR TITLE
Enable the release schedule in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  #schedule:
+  schedule:
   # Every Monday at 08:00 (UTC) - try to make sure it happens after all Kiali-related images are released
-  #- cron: '00 8 * * MON'
+  - cron: '00 8 * * MON'
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
### Describe the change

Now that we have tested the new release GitHub Action and confirmed it works properly, it is time to enable the automated release schedule.

### Steps to test the PR

Verify that the github action is correct.

### Automation testing

N/A