### PR TITLE
[operator] explicitly set metrics bind address to 8080

### DIFF
--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - "--leader-election-id={{ include "kiali-operator.fullname" . }}"
         - "--watches-file=./$(WATCHES_FILE)"
         - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=:8080"
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           httpGet:


### PR DESCRIPTION
the default value used to be 8080 but in ansible operator 1.36.0, that default was changed to 8443. So we need to explicitly set it 8080 now.

This goes with operator PR https://github.com/kiali/kiali-operator/pull/857