### PR TITLE
support topologySpreadConstraints in Deployment config

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -239,5 +239,9 @@ spec:
       nodeSelector:
       {{- toYaml .Values.deployment.node_selector | nindent 8 }}
       {{- end }}
+      {{- if .Values.deployment.topology_spread_constraints }}
+      topologySpreadConstraints:
+      {{- toYaml .Values.deployment.topology_spread_constraints | nindent 8 }}
+      {{- end }}
 ...
 {{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -94,6 +94,7 @@ deployment:
   service_annotations: {}
   service_type: ""
   tolerations: []
+  topology_spread_constraints: []
   version_label: ${HELM_IMAGE_TAG} # v1.39 # v1.39.0 # see: https://quay.io/repository/kiali/kiali?tab=tags
   view_only_mode: false
 


### PR DESCRIPTION
part of : https://github.com/kiali/kiali/issues/5614

To quickly test:

1. Build the charts: `make build-helm-charts`
2. Set some topology spread constraints to see that it gets into the deployment yaml:
```bash
helm template -n istio-system \
  --show-only templates/deployment.yaml \
  --set deployment.topology_spread_constraints[0].maxSkew=1 \
  --set deployment.topology_spread_constraints[0].whenUnsatisfiable=DoNotSchedule \
  --set deployment.topology_spread_constraints[0].topologyKey=kubernetes.io/hostname \
  kiali-server \
  _output/charts/kiali-server-*.tgz
```
3. See that the spec.topologySpreadConstraints yaml is in the yaml
4. Now see that if you do not specify topology spread constraints, the yaml does not show anything:
```
helm template -n istio-system --show-only templates/deployment.yaml kiali-server _output/charts/kiali-server-*.tgz
```