### PR TITLE
optionally mount secret volume kiali-multi-cluster-secret

### DIFF
--- a/kiali-server/templates/deployment.yaml
+++ b/kiali-server/templates/deployment.yaml
@@ -156,14 +156,19 @@ spec:
         - name: {{ .name }}
           mountPath: "{{ .mount }}"
         {{- end }}
+        - name: "kiali-multi-cluster-secret"
+          mountPath: "/kiali-remote-cluster-secrets/kiali-multi-cluster-secret"
+          readOnly: true
         {{- range $key, $val := (include "kiali-server.remote-cluster-secrets" .) | fromJson }}
         - name: {{ $key }}
           mountPath: "/kiali-remote-cluster-secrets/{{ $val }}"
+          readOnly: true
         {{- end }}
         {{- range .Values.clustering.clusters }}
-        {{- if .secret_name }}
+        {{- if and (.secret_name) (ne .secret_name "kiali-multi-cluster-secret") }}
         - name: {{ .name }}
           mountPath: "/kiali-remote-cluster-secrets/{{ .secret_name }}"
+          readOnly: true
         {{- end }}
         {{- end }}
         {{- if .Values.deployment.resources }}
@@ -204,13 +209,17 @@ spec:
           optional: {{ .optional | default false }}
       {{- end }}
       {{- end }}
+      - name: "kiali-multi-cluster-secret"
+        secret:
+          secretName: "kiali-multi-cluster-secret"
+          optional: true
       {{- range $key, $val := (include "kiali-server.remote-cluster-secrets" .) | fromJson }}
       - name: {{ $key }}
         secret:
           secretName: {{ $val }}
       {{- end }}
       {{- range .Values.clustering.clusters }}
-      {{- if .secret_name }}
+      {{- if and (.secret_name) (ne .secret_name "kiali-multi-cluster-secret") }}
       - name: {{ .name }}
         secret:
           secretName: {{ .secret_name }}


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7877

This will always mount secret `kiali-multi-cluster-secret` - but it is optional. If the secret doesn't exist, the server will still start.

The secret does not need to be labeled  - it simply needs to have its name be "kiali-multi-cluster-secret"

To test, I first created a remote secret using our hack script (my minikube cluster is named "ci"):

```
hack/istio/multicluster/kiali-prepare-remote-cluster.sh -astv false --dry-run true -prr false -kcc current -rcc ci
```

The resulting secret yaml was then modified - I removed the annotation and label and I renamed it "kiali-multi-cluster-secret" - I stored it in a file "secret.yaml". I then "kubectl apply -f secret.yaml -n istio-system" to create the secret.

Then you can run helm install to see that it was deployed:

```
make build-helm-charts

helm install -n istio-system --set deployment.logger.log_level=debug --set deployment.image_version=latest kiali-server _output/charts/kiali-server-*.tgz
```

Look at the Deployment yaml for the new mount:

```
        volumeMounts:
...
        - mountPath: /kiali-remote-cluster-secrets/kiali-multi-cluster-secret
          name: kiali-multi-cluster-secret
...
      volumes:
...
      - name: kiali-multi-cluster-secret
        secret:
          defaultMode: 420
          optional: true
          secretName: kiali-multi-cluster-secret

```

you should also see log message at DBG level showing you it picked up the cluster secret info -- something like this:

```
2025-03-19T18:43:57Z DBG Data for remote cluster [ci] has been loaded from secret file [/kiali-remote-cluster-secrets/kiali-multi-cluster-secret/ci]
```