### PR TITLE
kiali-server: disable RBACs if deployment.cluster_wide_access is false

### DIFF
--- a/kiali-server/templates/clusterrole-viewer.yaml
+++ b/kiali-server/templates/clusterrole-viewer.yaml
@@ -1,9 +1,10 @@
-{{- if not (or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous")) -}}
+{{- if .Values.deployment.cluster_wide_access -}}
+{{- if or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous") -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kiali-server.fullname" . }}
+  name: {{ include "kiali-server.fullname" . }}-viewer
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
@@ -28,7 +29,6 @@ rules:
   - get
   - list
   - watch
-  - patch
 - apiGroups: [""]
   resources:
   - pods/portforward
@@ -45,7 +45,6 @@ rules:
   - get
   - list
   - watch
-  - patch
 - apiGroups: ["batch"]
   resources:
   - cronjobs
@@ -54,7 +53,6 @@ rules:
   - get
   - list
   - watch
-  - patch
 - apiGroups:
   - networking.istio.io
   - security.istio.io
@@ -66,9 +64,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - delete
-  - patch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs
@@ -76,7 +71,6 @@ rules:
   - get
   - list
   - watch
-  - patch
 - apiGroups: ["project.openshift.io"]
   resources:
   - projects
@@ -107,4 +101,5 @@ rules:
   - list
   - watch
 ...
+{{- end -}}
 {{- end -}}

--- a/kiali-server/templates/clusterrole.yaml
+++ b/kiali-server/templates/clusterrole.yaml
@@ -1,9 +1,10 @@
-{{- if or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous") -}}
+{{- if .Values.deployment.cluster_wide_access -}}
+{{- if not (or (.Values.deployment.view_only_mode) (ne .Values.auth.strategy "anonymous")) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kiali-server.fullname" . }}-viewer
+  name: {{ include "kiali-server.fullname" . }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}
 rules:
@@ -28,6 +29,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups: [""]
   resources:
   - pods/portforward
@@ -44,6 +46,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups: ["batch"]
   resources:
   - cronjobs
@@ -52,6 +55,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - networking.istio.io
   - security.istio.io
@@ -63,6 +67,9 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - patch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs
@@ -70,6 +77,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups: ["project.openshift.io"]
   resources:
   - projects
@@ -100,4 +108,5 @@ rules:
   - list
   - watch
 ...
+{{- end -}}
 {{- end -}}

--- a/kiali-server/templates/clusterrolebinding.yaml
+++ b/kiali-server/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployment.cluster_wide_access -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -22,3 +23,4 @@ subjects:
   name: {{ include "kiali-server.fullname" . }}
   namespace: "{{ .Release.Namespace }}"
 ...
+{{- end -}}


### PR DESCRIPTION
# Problem

In clusters with dozens of Istio control plane namespaces, the Kiali Operator (using its Ansible playbooks) does not scale well and consumes an abnormal amount of memory.
To work around this issue, we have switched to using the kiali-server Helm chart instead.

However, it is currently not possible to disable the creation of ClusterRole and ClusterRoleBinding resources, which prevents us from managing RBAC externally — a requirement for our multi-tenancy setup.

# Proposed Change

This PR introduces a change that allows disabling RBAC creation when:
```
.Values.deployment.cluster_wide_access: false
```
This gives users more control over RBAC configuration and aligns better with environments that manage permissions externally.
