### PR TITLE
[CI] delay helm chart release workflow by one hour

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   schedule:
-  # Every Monday at 08:00 (UTC) - try to make sure it happens after all Kiali-related images are released
-  - cron: '00 8 * * MON'
+  # Every Monday at 09:00 (UTC) - try to make sure it happens after all Kiali-related images are released
+  - cron: '00 9 * * MON'
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
We want helm chart release to happen after all other release jobs are done and quay images are published.