### PR TITLE
[UI] CRD: enum for health_config.compute.duration

### DIFF
--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -1641,9 +1641,10 @@ spec:
                     type: object
                     properties:
                       duration:
-                        description: "The time period over which health is calculated. Used as the rate interval for Prometheus queries. Minimum is '1m'."
-                        type: string
                         default: "5m"
+                        description: "The time period over which health is calculated. Used as the rate interval for Prometheus queries. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
+                        enum: ["1m", "2m", "5m", "10m", "30m", "1h", "3h", "6h", "12h", "1d", "7d", "30d"]
+                        type: string
                       refresh_interval:
                         description: "The interval between health cache refreshes."
                         type: string

--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -1642,7 +1642,7 @@ spec:
                     properties:
                       duration:
                         default: "5m"
-                        description: "The time period over which health is calculated. Used as the rate interval for Prometheus queries. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
+                        description: "The time period over which health is calculated. Used as the rate interval for Prometheus queries."
                         enum: ["1m", "2m", "5m", "10m", "30m", "1h", "3h", "6h", "12h", "1d", "7d", "30d"]
                         type: string
                       refresh_interval:


### PR DESCRIPTION
Part-of https://github.com/kiali/kiali/issues/9474

Match allowed values to kiali_feature_flags.ui_defaults.metrics_per_refresh (1m through 30d). Document in field description.

Made-with: Cursor