### PR TITLE
Add x-kubernetes-preserve-unknown-fields to CRD

### DIFF
--- a/kiali-operator/templates/ossmconsole-crd.yaml
+++ b/kiali-operator/templates/ossmconsole-crd.yaml
@@ -113,5 +113,5 @@ spec:
                   servicePort:
                     description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
                     type: integer
-...
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}


### PR DESCRIPTION
Running the Molecule Pipeline, fixing the failure