### PR TITLE
Add kiali_feature_flags.authz.require_namespace_get config option

### DIFF
--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -1742,6 +1742,7 @@ spec:
                           is trusted without per-namespace GET checks. Enable this in multi-tenant environments
                           where LIST permission is granted broadly but GET is restricted per namespace.
                         type: boolean
+                        default: false
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -1731,6 +1731,17 @@ spec:
                 description: "Kiali features that can be enabled or disabled."
                 type: object
                 properties:
+                  authz:
+                    description: "Authorization-related feature flags."
+                    type: object
+                    properties:
+                      require_namespace_get:
+                        description: |
+                          When true, a user must have GET permission on a namespace for it to be visible,
+                          even if the user has LIST permission. When false (the default), a successful LIST
+                          is trusted without per-namespace GET checks. Enable this in multi-tenant environments
+                          where LIST permission is granted broadly but GET is restricted per namespace.
+                        type: boolean
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -162,6 +162,8 @@ identity: {}
   #private_key_file:
 
 kiali_feature_flags:
+  authz:
+    require_namespace_get: false
   custom_workload_types: []
   disabled_features: []
   validations:

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -162,8 +162,6 @@ identity: {}
   #private_key_file:
 
 kiali_feature_flags:
-  authz:
-    require_namespace_get: false
   custom_workload_types: []
   disabled_features: []
   validations:


### PR DESCRIPTION
Part-of: https://github.com/kiali/kiali/issues/7125

## Summary
- Syncs CRD with the new `authz.require_namespace_get` property from kiali/kiali-operator
- Adds `authz.require_namespace_get: false` default to `kiali-server/values.yaml`

Made with [Cursor](https://cursor.com)