### PR TITLE
feat(kiali-server): add opt-in PodDisruptionBudget (pod_disruption_bddget) Related: https://github.com/kiali/kiali/issues/9590

### DIFF
--- a/kiali-server/templates/pdb.yaml
+++ b/kiali-server/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if .Values.deployment.pod_disruption_budget.spec }}
+---
+apiVersion: {{ .Values.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.deployment.pod_disruption_budget.spec | nindent 2 }}
+...
+{{- end }}
+{{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -92,6 +92,9 @@ deployment:
   hpa:
     api_version: "autoscaling/v2"
     spec: {}
+  pod_disruption_budget:
+    api_version: "policy/v1"
+    spec: {}
   image_digest: "" # use "sha256" if image_version is a sha256 hash (do NOT prefix this value with a "@")
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"

--- a/tests/kiali-server-tests/deployment-remote-cluster-resources-only.yaml
+++ b/tests/kiali-server-tests/deployment-remote-cluster-resources-only.yaml
@@ -6,6 +6,8 @@ helm_args:
   - "--set"
   - "deployment.hpa.spec.maxReplicas=5"
   - "--set"
+  - "deployment.pod_disruption_budget.spec.minAvailable=1"
+  - "--set"
   - "deployment.ingress.enabled=true"
 yq_query: ".kind"
 expected_result: |

--- a/tests/kiali-server-tests/pdb-configuration.yaml
+++ b/tests/kiali-server-tests/pdb-configuration.yaml
@@ -1,0 +1,17 @@
+name: "pdb_configuration"
+description: "Verify PDB is created when spec is provided"
+helm_args:
+  - "--set"
+  - "deployment.pod_disruption_budget.api_version=policy/v1"
+  - "--set"
+  - "deployment.pod_disruption_budget.spec.minAvailable=1"
+yq_query: "select(.kind == \"PodDisruptionBudget\") | {\"apiVersion\": .apiVersion, \"spec\": {\"minAvailable\": .spec.minAvailable, \"selector\": .spec.selector}}"
+expected_result: |
+  apiVersion: policy/v1
+  spec:
+    minAvailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: kiali
+        app.kubernetes.io/instance: kiali
+should_fail: false

--- a/tests/kiali-server-tests/pdb-no-spec.yaml
+++ b/tests/kiali-server-tests/pdb-no-spec.yaml
@@ -1,0 +1,9 @@
+name: "pdb_no_spec"
+description: "Verify PDB is not created when spec is empty"
+# Non-empty helm_args avoids unbound helm_args[@] in run-helm-chart-tests.sh (set -u).
+helm_args:
+  - "--set"
+  - "deployment.replicas=1"
+yq_query: "select(.kind == \"PodDisruptionBudget\")"
+expected_result: ""
+should_fail: false


### PR DESCRIPTION
feat(kiali-server): add opt-in PodDisruptionBudget (pod_disruption_bddget) Related: https://github.com/kiali/kiali/issues/9590

 ## Helm Chart Tests
```
➜  kiali-helm-charts git:(feature/pod-disruption-budget-helm-9590) ✗ ./tests/run-helm-chart-tests.sh pdb-configuration pdb-no-spec deployment-remote-cluster-resources-only

=====================================================================
 Kiali Helm Chart Test Runner (server tests)
=====================================================================

=====================================================================
 Checking Prerequisites
=====================================================================
[PASS] All prerequisites met

=====================================================================
 Building Helm Charts
=====================================================================
[INFO] Cleaning previous builds...
[INFO] Building helm charts...
Using helm from PATH: /opt/homebrew/bin/helm
Will use this helm executable: helm
helm version
version.BuildInfo{Version:"v3.18.3", GitCommit:"6838ebcf265a3842d1433956e8a622e3290cf324", GitTreeState:"clean", GoVersion:"go1.24.4"}
Building Helm Chart for Kiali operator
==> Linting /kiali-helm-charts/_output/charts/kiali-operator

1 chart(s) linted, 0 chart(s) failed
Successfully packaged chart and saved it to: /kiali-helm-charts/_output/charts/kiali-operator-2.26.0-SNAPSHOT.tgz
Building Helm Chart for Kiali server
==> Linting /kiali-helm-charts/_output/charts/kiali-server

1 chart(s) linted, 0 chart(s) failed
Successfully packaged chart and saved it to: /kiali-helm-charts/_output/charts/kiali-server-2.26.0-SNAPSHOT.tgz
[PASS] Helm charts built successfully

=====================================================================
 Running Specific Tests: pdb-configuration pdb-no-spec deployment-remote-cluster-resources-only
=====================================================================
[INFO] Found 125 test files
[PASS] [1] deployment_remote_cluster_resources_only (deployment-remote-cluster-resources-only.yaml): Output matches expected result
[PASS] [2] pdb_configuration (pdb-configuration.yaml): Output matches expected result
[PASS] [3] pdb_no_spec (pdb-no-spec.yaml): Output matches expected result

=====================================================================
 Test Summary
=====================================================================
Tests Run: 3
Tests Passed: 3
Tests Failed: 0

[PASS] All tests passed! ✅

[INFO] The kiali-server Helm chart is working correctly.
```
