### PR TITLE
Add PodDisruptionBudget support

### DIFF
--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -810,6 +810,27 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  pod_disruption_budget:
+                    description: |
+                      Determines what (if any) PodDisruptionBudget should be created for the Kiali pod.
+                      A typical way to configure PDB for Kiali is,
+                      ```
+                      spec:
+                        deployment:
+                          pod_disruption_budget:
+                            api_version: "policy/v1"
+                            spec:
+                              minAvailable: 1
+                      ```
+                    type: object
+                    properties:
+                      api_version:
+                        description: "A specific PDB API version that can be specified in case there is some PDB feature you want to use that is only supported in that specific version. If value is an empty string, the default version of 'policy/v1' will be used."
+                        type: string
+                      spec:
+                        description: "The `spec` specified here will be placed in the created PDB resource's 'spec' section. If `spec` is left empty, no PDB resource will be created. Note that you must not specify the 'selector' section in `spec`; the Kiali Operator will populate that for you."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   pod_labels:
                     description: |
                       Custom labels to be created on the Kiali pod.

--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -81,6 +81,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups: ["monitoring.coreos.com"]
   resources:
   - servicemonitors

--- a/kiali-server/templates/pdb.yaml
+++ b/kiali-server/templates/pdb.yaml
@@ -1,7 +1,7 @@
 {{- if not .Values.deployment.remote_cluster_resources_only }}
 {{- if .Values.deployment.pod_disruption_budget.spec }}
 ---
-apiVersion: {{ .Values.deployment.pod_disruption_budget.api_version }}
+apiVersion: {{ .Values.deployment.pod_disruption_budget.api_version | quote }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "kiali-server.fullname" . }}

--- a/kiali-server/templates/pdb.yaml
+++ b/kiali-server/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if .Values.deployment.pod_disruption_budget.spec }}
+---
+apiVersion: {{ .Values.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "kiali-server.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kiali-server.selectorLabels" . | nindent 6 }}
+  {{- toYaml .Values.deployment.pod_disruption_budget.spec | nindent 2 }}
+...
+{{- end }}
+{{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -92,6 +92,9 @@ deployment:
   hpa:
     api_version: "autoscaling/v2"
     spec: {}
+  pod_disruption_budget:
+    api_version: "policy/v1"
+    spec: {}
   image_digest: "" # use "sha256" if image_version is a sha256 hash (do NOT prefix this value with a "@")
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -92,9 +92,6 @@ deployment:
   hpa:
     api_version: "autoscaling/v2"
     spec: {}
-  pod_disruption_budget:
-    api_version: "policy/v1"
-    spec: {}
   image_digest: "" # use "sha256" if image_version is a sha256 hash (do NOT prefix this value with a "@")
   image_name: quay.io/kiali/kiali
   image_pull_policy: "Always"
@@ -117,6 +114,9 @@ deployment:
   node_selector: {}
   pod_annotations:
     proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+  pod_disruption_budget:
+    api_version: "policy/v1"
+    spec: {}
   pod_labels: {}
   priority_class_name: ""
   probes:

--- a/tests/kiali-server-tests/deployment-remote-cluster-resources-only.yaml
+++ b/tests/kiali-server-tests/deployment-remote-cluster-resources-only.yaml
@@ -6,6 +6,8 @@ helm_args:
   - "--set"
   - "deployment.hpa.spec.maxReplicas=5"
   - "--set"
+  - "deployment.pod_disruption_budget.spec.minAvailable=1"
+  - "--set"
   - "deployment.ingress.enabled=true"
 yq_query: ".kind"
 expected_result: |

--- a/tests/kiali-server-tests/pdb-configuration.yaml
+++ b/tests/kiali-server-tests/pdb-configuration.yaml
@@ -7,7 +7,7 @@ helm_args:
   - "deployment.pod_disruption_budget.spec.minAvailable=1"
 yq_query: "select(.kind == \"PodDisruptionBudget\") | {\"apiVersion\": .apiVersion, \"spec\": {\"minAvailable\": .spec.minAvailable, \"selector\": .spec.selector}}"
 expected_result: |
-  apiVersion: policy/v1
+  apiVersion: "policy/v1"
   spec:
     minAvailable: 1
     selector:

--- a/tests/kiali-server-tests/pdb-configuration.yaml
+++ b/tests/kiali-server-tests/pdb-configuration.yaml
@@ -1,0 +1,17 @@
+name: "pdb_configuration"
+description: "Verify PDB is created when spec is provided"
+helm_args:
+  - "--set"
+  - "deployment.pod_disruption_budget.api_version=policy/v1"
+  - "--set"
+  - "deployment.pod_disruption_budget.spec.minAvailable=1"
+yq_query: "select(.kind == \"PodDisruptionBudget\") | {\"apiVersion\": .apiVersion, \"spec\": {\"minAvailable\": .spec.minAvailable, \"selector\": .spec.selector}}"
+expected_result: |
+  apiVersion: policy/v1
+  spec:
+    minAvailable: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: kiali
+        app.kubernetes.io/instance: kiali
+should_fail: false

--- a/tests/kiali-server-tests/pdb-no-spec.yaml
+++ b/tests/kiali-server-tests/pdb-no-spec.yaml
@@ -1,0 +1,9 @@
+name: "pdb_no_spec"
+description: "Verify PDB is not created when spec is empty"
+# Non-empty helm_args avoids unbound helm_args[@] in run-helm-chart-tests.sh (set -u).
+helm_args:
+  - "--set"
+  - "deployment.replicas=1"
+yq_query: "select(.kind == \"PodDisruptionBudget\")"
+expected_result: ""
+should_fail: false


### PR DESCRIPTION
Add opt-in PodDisruptionBudget (PDB) support, mirroring the existing HorizontalPodAutoscaler pattern. Users can configure a PDB via the new `deployment.pod_disruption_budget` field.

Goes along with operator PR: https://github.com/kiali/kiali-operator/pull/1029

Part of: https://github.com/kiali/kiali/issues/9590