### PR TITLE
Add ability to enable/disable Prometheus via external_services.prometheus.enabled

### DIFF
--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -1483,6 +1483,10 @@ spec:
                         type: object
                         additionalProperties:
                           type: string
+                      enabled:
+                        description: "When true, Kiali will connect to the Prometheus instance for Istio telemetry metrics. When false, Kiali will run without metrics support - the graph, health based on request rates, and metrics displays will be unavailable."
+                        type: boolean
+                        default: true
                       health_check_url:
                         description: "Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided."
                         type: string

--- a/kiali-server/templates/_helpers.tpl
+++ b/kiali-server/templates/_helpers.tpl
@@ -542,8 +542,8 @@ Example output:
 {{- $secrets := dict }}
 
 {{- if .Values.external_services }}
-  {{- /* Prometheus - always processed, no enabled check */ -}}
-  {{- if and .Values.external_services.prometheus .Values.external_services.prometheus.auth }}
+  {{- /* Prometheus - only if enabled (defaults to true when not set) */ -}}
+  {{- if and .Values.external_services.prometheus (not (eq (toString .Values.external_services.prometheus.enabled) "false")) .Values.external_services.prometheus.auth }}
     {{- $secrets = merge $secrets (include "kiali-server.process-auth-secrets" (dict "auth" .Values.external_services.prometheus.auth "prefix" "prometheus") | fromJson) }}
   {{- end }}
 

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -159,6 +159,8 @@ external_services:
     enabled: true
   istio:
     root_namespace: ""
+  prometheus:
+    enabled: true
 
 identity: {}
   #cert_file:

--- a/tests/kiali-server-tests/credential-secret-prometheus-disabled.yaml
+++ b/tests/kiali-server-tests/credential-secret-prometheus-disabled.yaml
@@ -1,0 +1,11 @@
+name: "credential_secret_prometheus_disabled"
+description: "Verify prometheus credentials are NOT mounted when prometheus.enabled is false"
+helm_args:
+  - "--set"
+  - "external_services.prometheus.enabled=false"
+  - "--set"
+  - "external_services.prometheus.auth.password=secret:prom-creds:password"
+yq_query: "select(.kind == \"Deployment\") | (.spec.template.spec.volumes | map(select(.name == \"prometheus-password\")) | length)"
+expected_result: |
+  0
+should_fail: false


### PR DESCRIPTION
Introduce a new `external_services.prometheus.enabled` configuration field (default true) that allows Kiali to run without a Prometheus metrics store. When disabled, a no-op Prometheus client is injected so the server starts without a Prometheus connection. Metrics-dependent features degrade gracefully: the graph page and mini-graph cards show an empty state with an explanation, health badges fall back to Kubernetes-only replica status, metrics and traffic tabs are hidden from detail pages, mesh target panels display a disabled message, and MCP/AI metric tools return an informative error. Non-metrics features (workload/service/app listing, Istio config, mesh topology, logs, traces) continue to work normally.

Changes span the Kiali server (config, noop client, handler guards, mesh generator, addon status, version probe), operator (CRD schema, defaults, conditional URL defaulting and secret mounts), Helm charts (credential gating, values, template tests), frontend (config type, empty states, tab hiding, test data), molecule tests (baseline and disabled assertions in metrics-test and config-values-test), and kiali.io documentation.

Part of: https://github.com/kiali/kiali/issues/8654