### PR TITLE
Align GitHub Actions to latest versions across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Verify Kiali Server permissions
       env:

--- a/.github/workflows/helm-chart-tests.yml
+++ b/.github/workflows/helm-chart-tests.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Setup Helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       with:
         version: ${{ env.HELM_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
 
     - name: Upload server test artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: server-test-artifacts
         path: /tmp/kiali-helm-tests/
@@ -64,10 +64,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Setup Helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       with:
         version: ${{ env.HELM_VERSION }}
 
@@ -89,7 +89,7 @@ jobs:
 
     - name: Upload operator test artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: operator-test-artifacts
         path: /tmp/kiali-helm-tests/
@@ -101,15 +101,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Setup Helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78  # v3
+      uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
       with:
         version: ${{ env.HELM_VERSION }}
 
     - name: Create kind cluster
-      uses: helm/kind-action@0b5c88445f37b7e12a2ce1ecca7805b9046a74db  # v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
 
     - name: Verify cluster
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       branch_version: ${{ steps.branch_version.outputs.branch_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
         fetch-depth: 0
@@ -167,7 +167,7 @@ jobs:
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch || github.ref_name }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
         fetch-depth: 0

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Run smoke test hack script
       env:


### PR DESCRIPTION
### Describe the change

Align all GitHub Actions across workflows to their latest versions with pinned commit SHAs and precise version comments. This resolves Node.js 20 deprecation warnings.

- `actions/checkout`: v4 -> v6.0.2
- `azure/setup-helm`: v3 -> v5.0.0
- `actions/upload-artifact`: v4 -> v7.0.1
- `helm/kind-action`: v1 -> v1.14.0

### Steps to test the PR

- Verify CI and helm-chart-tests workflows pass
- No functional changes; only action version upgrades

Made with [Cursor](https://cursor.com)