### PR TITLE
Apply principle of least privilege to operator Helm chart RBAC

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -10,11 +10,8 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
-  - pods
   - serviceaccounts
   - services
-  - services/finalizers
   verbs:
   - create
   - delete
@@ -23,6 +20,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
 - apiGroups: [""]
   resources:
   - namespaces
@@ -61,7 +63,6 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - deployments
-  - replicasets
   verbs:
   - create
   - delete
@@ -92,19 +93,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups: ["monitoring.coreos.com"]
-  resources:
-  - servicemonitors
-  verbs:
-  - create
-  - get
-- apiGroups: ["apps"]
-  resourceNames:
-  - kiali-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
 - apiGroups: ["kiali.io"]
   resources:
   - '*'
@@ -120,7 +108,7 @@ rules:
   resources:
   - selfsubjectaccessreviews
   verbs:
-  - list
+  - create
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources:
   {{- if or (and (.Values.cr.create) (.Values.cr.spec.deployment.cluster_wide_access)) (.Values.clusterRoleCreator) }}
@@ -137,14 +125,7 @@ rules:
   - patch
   - update
   - watch
-- apiGroups: ["apiextensions.k8s.io"]
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - ingresses
   - networkpolicies
@@ -156,6 +137,7 @@ rules:
   - patch
   - update
   - watch
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
 - apiGroups: ["route.openshift.io"]
   resources:
   - routes
@@ -203,7 +185,6 @@ rules:
   - patch
   - update
   - watch
-{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
 # The permissions below are for OSSMC operator capabilities
 - apiGroups: ["console.openshift.io"]
   resources:
@@ -230,7 +211,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
   - pods/log
   verbs:
   - get
@@ -254,8 +234,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -280,10 +259,7 @@ rules:
   - patch
   {{- end }}
 - apiGroups:
-  - config.istio.io
   - networking.istio.io
-  - authentication.istio.io
-  - rbac.istio.io
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
@@ -299,6 +275,17 @@ rules:
   - delete
   - patch
   {{- end }}
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - list
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs
@@ -319,17 +306,6 @@ rules:
   - routes
   verbs:
   - get
-- apiGroups: ["authentication.k8s.io"]
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources:
-  - mutatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
+{{- end }}
 ...
 {{- end -}}

--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -263,7 +263,6 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
   verbs:
@@ -275,6 +274,40 @@ rules:
   - delete
   - patch
   {{- end }}
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - create
+  - delete
+  - patch
+  {{- end }}
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+  {{- if eq .Values.onlyViewOnlyMode false }}
+  - delete
+  - patch
+  {{- end }}
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["authentication.k8s.io"]
   resources:
   - tokenreviews

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -69,9 +69,21 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
   verbs:
   - get
   - list

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -24,7 +24,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {{- if not (has "logs-tab" $.Values.kiali_feature_flags.disabled_features) }}
   - pods/log
 {{- end }}
@@ -47,8 +46,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -106,9 +104,7 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 ...
 {{- end -}} {{/* range $namespace */}}
 {{- end -}} {{/* if view_only_mode or auth.strategy is not anonymous */}}

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -24,7 +24,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {{- if not (has "logs-tab" $.Values.kiali_feature_flags.disabled_features) }}
   - pods/log
 {{- end }}
@@ -48,8 +47,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -74,7 +72,6 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
   verbs:
@@ -84,6 +81,36 @@ rules:
   - create
   - delete
   - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs
@@ -113,9 +140,7 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 ...
 {{- end -}} {{/* range $namespace */}}
 {{- end -}} {{/* if not view_only_mode and auth.strategy is anonymous */}}

--- a/tests/kiali-server-tests/kiali-feature-flags-disabled-features.yaml
+++ b/tests/kiali-server-tests/kiali-feature-flags-disabled-features.yaml
@@ -11,5 +11,4 @@ expected_result: |
   hasPodLogPermission: false
   firstRuleResources:
     - configmaps
-    - endpoints
 should_fail: false

--- a/tests/kiali-server-tests/kiali-feature-flags-logs-enabled.yaml
+++ b/tests/kiali-server-tests/kiali-feature-flags-logs-enabled.yaml
@@ -9,6 +9,5 @@ expected_result: |
   hasPodLogPermission: true
   firstRuleResources:
     - configmaps
-    - endpoints
     - pods/log
 should_fail: false


### PR DESCRIPTION
## Summary

- Remove unused, excessive, and legacy RBAC permissions from the operator Helm chart ClusterRole
- Remove legacy Istio API groups (`config.istio.io`, `authentication.istio.io`, `rbac.istio.io`) and deprecated `extensions` apiGroup
- Remove operator-sdk v0.x boilerplate (`services/finalizers`, `deployments/finalizers`, `servicemonitors`, `customresourcedefinitions`)
- Fix invalid `post` verb on `pods/portforward` and incorrect `list` verb on `selfsubjectaccessreviews`
- Reduce `mutatingwebhookconfigurations` to `list`-only
- Remove `endpoints` from both operator management and Kiali server escalation sections
- Gate all OpenShift-specific permissions behind `route.openshift.io/v1` capability detection

## Test plan

- [ ] Verify Kiali deploys and functions correctly via Helm chart on Kubernetes
- [ ] Verify Kiali deploys and functions correctly via Helm chart on OpenShift

fixes: https://github.com/kiali/kiali/issues/9836

Made with [Cursor](https://cursor.com)