### PR TITLE
Add Gateway API HTTPRoute support to the kiali-server chart

### DIFF
--- a/kiali-server/templates/httproute.yaml
+++ b/kiali-server/templates/httproute.yaml
@@ -1,0 +1,50 @@
+{{- if not .Values.deployment.remote_cluster_resources_only }}
+{{- if .Values.deployment.httproute.enabled }}
+{{- $route := .Values.deployment.httproute }}
+{{- if not $route.parent_refs }}
+{{- fail "deployment.httproute.enabled is true but deployment.httproute.parent_refs is empty; an HTTPRoute needs at least one parentRef to attach to a Gateway" }}
+{{- end }}
+---
+apiVersion: {{ $route.api_version | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "kiali-server.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- if $route.additional_labels }}
+    {{- toYaml $route.additional_labels | nindent 4 }}
+    {{- end }}
+    {{- include "kiali-server.labels" . | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parent_refs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additional_rules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  - backendRefs:
+    - name: {{ include "kiali-server.fullname" . }}
+      port: {{ .Values.server.port }}
+    matches:
+      {{- if $route.matches }}
+      {{- toYaml $route.matches | nindent 6 }}
+      {{- else }}
+    - path:
+        type: PathPrefix
+        value: {{ include "kiali-server.server.web_root" . }}
+      {{- end }}
+    {{- with $route.filters }}
+    filters:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+...
+{{- end }}
+{{- end }}

--- a/kiali-server/values.yaml
+++ b/kiali-server/values.yaml
@@ -97,6 +97,32 @@ deployment:
   image_pull_policy: "Always"
   image_pull_secrets: []
   image_version: ${HELM_IMAGE_TAG} # version like "v1.39" (see: https://quay.io/repository/kiali/kiali?tab=tags) or a digest hash
+  httproute:
+    # Create an HTTPRoute (Gateway API) to expose the Kiali server UI on server.port.
+    # Requires the Gateway API CRDs to be installed in the cluster.
+    # Unlike "ingress" below, this is never created automatically on OpenShift; enable it explicitly.
+    enabled: false
+    # HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty).
+    api_version: ""
+    additional_labels: {}
+    annotations: {}
+    # parent_refs reference the Gateway(s) this HTTPRoute attaches to. Required when enabled.
+    # parent_refs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: http
+    parent_refs: []
+    # hostnames matched against the HTTP Host header to select this route (templated).
+    # hostnames:
+    #   - kiali.example.com
+    hostnames: []
+    # matches for the default rule. When empty, defaults to a PathPrefix match on the
+    # Kiali web root (mirrors the Ingress behavior below).
+    matches: []
+    # filters applied to the default rule.
+    filters: []
+    # additional_rules (templated) prepended before the default rule.
+    additional_rules: []
   ingress:
     additional_labels: {}
     class_name: "nginx"

--- a/tests/kiali-server-tests/httproute-configuration.yaml
+++ b/tests/kiali-server-tests/httproute-configuration.yaml
@@ -1,0 +1,22 @@
+name: "httproute_configuration"
+description: "Verify HTTPRoute parentRefs, hostnames, default backend port/path, and additional labels configuration"
+helm_args:
+  - "--set"
+  - "deployment.httproute.enabled=true"
+  - "--set"
+  - "deployment.httproute.parent_refs[0].name=my-gateway"
+  - "--set"
+  - "deployment.httproute.parent_refs[0].namespace=gateway-system"
+  - "--set"
+  - "deployment.httproute.hostnames[0]=kiali.example.com"
+  - "--set"
+  - "deployment.httproute.additional_labels.environment=production"
+yq_query: "select(.kind == \"HTTPRoute\") | {\"parentRef\": .spec.parentRefs[0].name, \"hostname\": .spec.hostnames[0], \"backendPort\": .spec.rules[0].backendRefs[0].port, \"pathType\": .spec.rules[0].matches[0].path.type, \"pathValue\": .spec.rules[0].matches[0].path.value, \"environmentLabel\": .metadata.labels.environment}"
+expected_result: |
+  parentRef: my-gateway
+  hostname: kiali.example.com
+  backendPort: 20001
+  pathType: PathPrefix
+  pathValue: /kiali
+  environmentLabel: production
+should_fail: false

--- a/tests/kiali-server-tests/httproute-missing-parent-refs.yaml
+++ b/tests/kiali-server-tests/httproute-missing-parent-refs.yaml
@@ -1,0 +1,7 @@
+name: "httproute_missing_parent_refs"
+description: "Verify HTTPRoute rendering fails fast when enabled but parent_refs is empty"
+helm_args:
+  - "--set"
+  - "deployment.httproute.enabled=true"
+should_fail: true
+expected_error_pattern: "deployment.httproute.parent_refs is empty"


### PR DESCRIPTION
Fixes: kiali/kiali#9876

Adds an opt-in HTTPRoute (Gateway API) to the kiali-server chart so the Kiali UI can be exposed through a Gateway, alongside the existing Ingress and OpenShift Route paths. Disabled by default; when `deployment.httproute.enabled=true` it attaches to the Gateway(s) named in `deployment.httproute.parent_refs` and routes to the server Service on `server.port`, defaulting to a PathPrefix match on the Kiali web root (mirroring the Ingress behavior).

Validation:
- `make run-helm-tests TEST_SUITE=server` → 155/155 pass (153 existing + 2 new)
- New tests: `httproute-configuration` (parentRefs / hostnames / backend port / default path / labels) and `httproute-missing-parent-refs` (fail-fast guard when `parent_refs` is empty)
- `helm lint` clean