### PR TITLE
Use KIALI_BOT_TOKEN for release workflow pushes to protected branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
         fetch-depth: 0
 
     - name: Prepare scripts
@@ -170,6 +171,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
         fetch-depth: 0
 
     - name: Configure git


### PR DESCRIPTION
## Summary
- The release workflow pushes directly to `$RELEASE_BRANCH` which is protected. The default `GITHUB_TOKEN` cannot push to protected branches.
- Use the `kiali-bot` PAT via `KIALI_BOT_TOKEN` in the `actions/checkout` step so that `git push` operations authenticate as `kiali-bot`, which has branch protection bypass.

## Related PRs
- kiali/kiali#9899
- kiali/kiali-operator#876
- kiali/openshift-servicemesh-plugin#559

## Test plan
- [ ] Verify the `KIALI_BOT_TOKEN` secret is available in the `kiali/helm-charts` repo
- [ ] Trigger a release and confirm pushes to protected branches succeed

Made with [Cursor](https://cursor.com)