### PR TITLE
Add udproutes RBAC for Gateway API 1.6 UDPRoute support

### DIFF
--- a/kiali-operator/templates/clusterrole.yaml
+++ b/kiali-operator/templates/clusterrole.yaml
@@ -293,6 +293,7 @@ rules:
   resources:
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list

--- a/kiali-server/templates/role-viewer.yaml
+++ b/kiali-server/templates/role-viewer.yaml
@@ -84,6 +84,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list

--- a/kiali-server/templates/role.yaml
+++ b/kiali-server/templates/role.yaml
@@ -98,6 +98,7 @@ rules:
   resources:
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list


### PR DESCRIPTION
## Summary
- Add `udproutes` to Kiali server and operator Helm chart RBAC rules alongside existing `tcproutes` and `tlsroutes` permissions.

## Why
Kiali #9859 adds Gateway API v1.6 `UDPRoute` support. When Gateway API 1.6 CRDs are installed (e.g. via Sail), Kiali must be able to list/watch `udproutes` or the MCP `manage_istio_config_read` list action can hang waiting on cache sync.

## Test plan
- [ ] Deploy Kiali with this chart on a cluster with Gateway API 1.6 CRDs
- [ ] Verify `kubectl auth can-i list udproutes --as=system:serviceaccount:istio-system:kiali -n bookinfo` succeeds
- [ ] MCP contract test `manage_istio_config_read` list action returns within a few seconds

## Issue reference
Ref kiali/kiali#9859

Core PR https://github.com/kiali/kiali/pull/10018

Made with [Cursor](https://cursor.com)