### PR TITLE
Implement OIDC RP-Initiated Logout

### DIFF
--- a/kiali-operator/crds/crds.yaml
+++ b/kiali-operator/crds/crds.yaml
@@ -186,6 +186,9 @@ spec:
                           authorization_endpoint:
                             type: string
                             description: "The URL of the provider's authorization endpoint."
+                          end_session_endpoint:
+                            type: string
+                            description: "The URL of the provider's RP-Initiated Logout endpoint. If set, logout will terminate both the local Kiali session and the IdP session. If not set, logout will only clear the local Kiali session."
                           jwks_uri:
                             type: string
                             description: "The URL of the provider's JWK Set document."
@@ -195,6 +198,9 @@ spec:
                           userinfo_endpoint:
                             type: string
                             description: "The URL of the provider's UserInfo endpoint."
+                      post_logout_redirect_uri:
+                        type: string
+                        description: "The URL to redirect the browser to after the IdP terminates the session during RP-Initiated Logout. Must be registered in the IdP's client configuration. If not set, defaults to the Kiali root URL."
                       username_claim:
                         type: string
                         default: "sub"


### PR DESCRIPTION
Add support for redirecting users to the OpenID provider's end_session_endpoint during logout, ensuring both the Kiali session and the IdP session are properly terminated. Includes new end_session_endpoint and post_logout_redirect_uri configuration options, frontend redirect handling, and end-to-end molecule test coverage.

Fixes: https://github.com/kiali/kiali/issues/10095

Generated-by: Cursor