### PR TITLE
Make the operator pod's probe timings configurable

### DIFF
--- a/docs/agents/kiali-operator-chart.md
+++ b/docs/agents/kiali-operator-chart.md
@@ -26,11 +26,6 @@ scribe:
       heading: Managed Kiali CR
   stale_flags: []
   review_notes:
-    - finding: "Startup probe parameters (initialDelaySeconds: 30, periodSeconds: 10, failureThreshold: 6) not documented — relevant for slow cluster deployments"
-      severity: minor
-      tag: TAG-011
-      confidence: 1.0
-      date: "2026-05-08"
     - finding: "debug.enabled defaults to true — full Ansible logs are dumped after each reconciliation by default, with log-volume implications"
       severity: minor
       tag: TAG-015

--- a/docs/agents/kiali-operator-chart.md
+++ b/docs/agents/kiali-operator-chart.md
@@ -26,6 +26,11 @@ scribe:
       heading: Managed Kiali CR
   stale_flags: []
   review_notes:
+    - finding: "Startup probe parameters (initialDelaySeconds: 30, periodSeconds: 10, failureThreshold: 6) not documented — relevant for slow cluster deployments"
+      severity: minor
+      tag: TAG-011
+      confidence: 1.0
+      date: "2026-05-08"
     - finding: "debug.enabled defaults to true — full Ansible logs are dumped after each reconciliation by default, with log-volume implications"
       severity: minor
       tag: TAG-015

--- a/docs/agents/kiali-operator-chart.md
+++ b/docs/agents/kiali-operator-chart.md
@@ -126,7 +126,7 @@ The namespace-watching variants (`watches-os-ns.yaml`, `watches-k8s-ns.yaml`) ar
 
 **Security context** — default is restrictive: `allowPrivilegeEscalation: false`, `privileged: false`, `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`, `capabilities.drop: [ALL]`. Overridable via `securityContext`. The pod mounts a `/tmp` emptyDir volume to give Ansible a writable scratch space under the read-only root.
 
-**Probes** — readiness checks `/readyz` on port 6789 (period 30s); liveness checks `/healthz` on port 6789 (period 30s); startup probe checks `/healthz` with `initialDelaySeconds: 30`, `periodSeconds: 10`, `failureThreshold: 6`.
+**Probes** — readiness checks `/readyz` on port 6789; liveness and startup check `/healthz` on the same port. All timings are configurable via `probes.*`. Defaults preserve the historical values: readiness and liveness both `periodSeconds: 30`; startup `initialDelaySeconds: 30`, `periodSeconds: 10`, `failureThreshold: 6`. The startup probe dominates how long the operator reports unready — it holds the pod back for at least `probes.startup.initialDelaySeconds` regardless of how fast the operator actually starts, so lower it on fast clusters where install time matters.
 
 **Metrics** — exposed on `:8080/metrics`. The pod annotation `prometheus.io/scrape` is set to `metrics.enabled` (default `true`).
 
@@ -156,6 +156,11 @@ The namespace-watching variants (`watches-os-ns.yaml`, `watches-k8s-ns.yaml`) ar
 | `allowAllAccessibleNamespaces` | `true` | Allow `cluster_wide_access: true` in Kiali CRs |
 | `skipResources` | `[]` | RBAC resources to skip (for external management) |
 | `metrics.enabled` | `true` | Expose Prometheus metrics on `:8080` |
+| `probes.readiness.periodSeconds` | `30` | Operator readiness probe period |
+| `probes.liveness.periodSeconds` | `30` | Operator liveness probe period |
+| `probes.startup.initialDelaySeconds` | `30` | Delay before the first operator startup probe |
+| `probes.startup.periodSeconds` | `10` | Operator startup probe period |
+| `probes.startup.failureThreshold` | `6` | Operator startup probe failures tolerated before restart |
 | `debug.enabled` | `true` | Dump full Ansible logs after each reconciliation (verbose by default) |
 | `debug.verbosity` | `"1"` | Ansible verbosity level (higher = more output) |
 | `debug.enableProfiler` | `false` | Log timing for expensive tasks |

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -58,19 +58,19 @@ spec:
           httpGet:
             path: /readyz
             port: 6789
-          periodSeconds: 30
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds | int | default 30 }}
         livenessProbe:
           httpGet:
             path: /healthz
             port: 6789
-          periodSeconds: 30
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds | int | default 30 }}
         startupProbe:
           httpGet:
             path: /healthz
             port: 6789
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          failureThreshold: 6
+          initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | int | default 30 }}
+          periodSeconds: {{ .Values.probes.startup.periodSeconds | int | default 10 }}
+          failureThreshold: {{ .Values.probes.startup.failureThreshold | int | default 6 }}
         securityContext:
         {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 10 }}

--- a/kiali-operator/templates/deployment.yaml
+++ b/kiali-operator/templates/deployment.yaml
@@ -58,19 +58,19 @@ spec:
           httpGet:
             path: /readyz
             port: 6789
-          periodSeconds: {{ .Values.probes.readiness.periodSeconds | int | default 30 }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds | int }}
         livenessProbe:
           httpGet:
             path: /healthz
             port: 6789
-          periodSeconds: {{ .Values.probes.liveness.periodSeconds | int | default 30 }}
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds | int }}
         startupProbe:
           httpGet:
             path: /healthz
             port: 6789
-          initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | int | default 30 }}
-          periodSeconds: {{ .Values.probes.startup.periodSeconds | int | default 10 }}
-          failureThreshold: {{ .Values.probes.startup.failureThreshold | int | default 6 }}
+          initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | int }}
+          periodSeconds: {{ .Values.probes.startup.periodSeconds | int }}
+          failureThreshold: {{ .Values.probes.startup.failureThreshold | int }}
         securityContext:
         {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 10 }}

--- a/kiali-operator/values.yaml
+++ b/kiali-operator/values.yaml
@@ -24,6 +24,21 @@ replicaCount: 1
 priorityClassName: ""
 securityContext: {}
 
+# Configures the liveness, readiness, and startup probes of the operator pod.
+# The defaults are conservative so the operator comes up reliably on slow clusters.
+# Note that the startup probe keeps the operator unready for at least
+# probes.startup.initialDelaySeconds regardless of how fast it actually starts,
+# so lower that value if you need the operator to report ready sooner.
+probes:
+  liveness:
+    periodSeconds: 30
+  readiness:
+    periodSeconds: 30
+  startup:
+    failureThreshold: 6
+    initialDelaySeconds: 30
+    periodSeconds: 10
+
 # This helm chart will create Kubernetes resources such as cluster roles, cluster role bindings, and service accounts.
 # For very rare use-cases, users may want to manage some of these resources manually, outside
 # of this helm chart. In cases like this, you can inform this helm chart to skip the creation of

--- a/tests/kiali-operator-tests/deployment-probes-custom.yaml
+++ b/tests/kiali-operator-tests/deployment-probes-custom.yaml
@@ -1,0 +1,25 @@
+name: "deployment_probes_custom"
+description: "Verify custom probe timings for the operator pod"
+helm_args:
+  - "--set"
+  - "probes.readiness.periodSeconds=15"
+  - "--set"
+  - "probes.liveness.periodSeconds=60"
+  - "--set"
+  - "probes.startup.initialDelaySeconds=5"
+  - "--set"
+  - "probes.startup.periodSeconds=2"
+  - "--set"
+  - "probes.startup.failureThreshold=30"
+yq_query: "select(.kind == \"Deployment\") | .spec.template.spec.containers[0] | {\"readinessPeriod\": .readinessProbe.periodSeconds, \"livenessPeriod\": .livenessProbe.periodSeconds, \"startupProbe\": .startupProbe}"
+expected_result: |
+  readinessPeriod: 15
+  livenessPeriod: 60
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: 6789
+    initialDelaySeconds: 5
+    periodSeconds: 2
+    failureThreshold: 30
+should_fail: false

--- a/tests/kiali-operator-tests/deployment-probes-defaults.yaml
+++ b/tests/kiali-operator-tests/deployment-probes-defaults.yaml
@@ -1,0 +1,23 @@
+name: "deployment_probes_defaults"
+description: "Verify the default probe configuration is unchanged when no probe values are set"
+helm_args: []
+yq_query: "select(.kind == \"Deployment\") | .spec.template.spec.containers[0] | {\"readinessProbe\": .readinessProbe, \"livenessProbe\": .livenessProbe, \"startupProbe\": .startupProbe}"
+expected_result: |
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: 6789
+    periodSeconds: 30
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 6789
+    periodSeconds: 30
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: 6789
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 6
+should_fail: false

--- a/tests/kiali-operator-tests/deployment-probes-zero-initial-delay.yaml
+++ b/tests/kiali-operator-tests/deployment-probes-zero-initial-delay.yaml
@@ -1,0 +1,15 @@
+name: "deployment_probes_zero_initial_delay"
+description: "Verify an explicit startup probe initialDelaySeconds of 0 is honored and not replaced by the default"
+helm_args:
+  - "--set"
+  - "probes.startup.initialDelaySeconds=0"
+yq_query: "select(.kind == \"Deployment\") | .spec.template.spec.containers[0] | {\"startupProbe\": .startupProbe}"
+expected_result: |
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: 6789
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    failureThreshold: 6
+should_fail: false


### PR DESCRIPTION
## Problem

The operator Deployment hardcodes its readiness, liveness and startup probe timings, so there is no way to tune them from the chart. `startupProbe.initialDelaySeconds: 30` in particular keeps the operator unready for at least 30 seconds no matter how quickly it actually starts, which dominates install time on fast clusters.

## Change

Moves the timings into a `probes.*` values block, mirroring what the Kiali CR already offers for the server via `spec.deployment.probes`:

```yaml
probes:
  liveness:
    periodSeconds: 30
  readiness:
    periodSeconds: 30
  startup:
    failureThreshold: 6
    initialDelaySeconds: 30
    periodSeconds: 10
```

The existing numbers become the defaults, so rendered output is unchanged unless a value is explicitly set.

Naming is camelCase to match the rest of `kiali-operator/values.yaml`. The server chart uses snake_case only because those values mirror the CR schema.

Closes https://github.com/kiali/kiali/issues/10132

## Testing

- `make clean build-helm-charts` — clean
- `./tests/run-helm-chart-tests.sh --test-suite operator` — 32/32 pass
- Two new tests: `deployment-probes-defaults.yaml` pins the current output so the defaults can't drift, `deployment-probes-custom.yaml` exercises the overrides

## Disclosure

Per the [AI policy](https://github.com/kiali/kiali/blob/master/AI_POLICY.md): this change was drafted with AI assistance and is being reviewed by me before it leaves draft.